### PR TITLE
PKG -- [sdk] Allows authorizer payer and proposer to be the same acct

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 - 2020-05-07 -- Params resolver parses params correctly
+- 2020-05-07 -- Allows authorizer payer and proposer to be the same
 
 ### 0.0.17 -- 2020-05-06
 

--- a/packages/sdk/src/resolve/resolve-signatures.js
+++ b/packages/sdk/src/resolve/resolve-signatures.js
@@ -101,7 +101,7 @@ export async function resolveSignatures(ix) {
     keyId: payer.keyId,
     roles: {
       proposer: proposer.addr === payer.addr,
-      authorizer: false,
+      authorizer: Boolean(authorizors.find(a => a.addr === payer.addr)),
       payer: true,
     },
     interaction: ix,


### PR DESCRIPTION
PKG -- [sdk] Allows authorizer payer and proposer to be the same acct