### PR TITLE
Remove authn/authz iframe border

### DIFF
--- a/packages/fcl/src/current-user/render-frame.js
+++ b/packages/fcl/src/current-user/render-frame.js
@@ -18,7 +18,6 @@ export function renderFrame(src) {
   $frame.style.background = "rgba(0,0,0,0.25)"
   $frame.frameBorder = "0"
   $frame.style.boxSizing = "border-box"
-  $frame.style.border = "1px solid white"
   document.body.append($frame)
 
   const unmount = () => {


### PR DESCRIPTION
Currently there's a white border around Authn/Authz iframes which can look strange especially for dApps with dark background.
![Screen Shot 2020-09-16 at 11 55 20 AM](https://user-images.githubusercontent.com/1079990/93290551-91a81400-f813-11ea-8282-74fe10fae1e7.png)

I think the overall look and feel for dApps + wallet can be improved without this border.