### PR TITLE
Fix when multiple authorizer have same address

### DIFF
--- a/packages/sdk-resolve-signatures/src/index.js
+++ b/packages/sdk-resolve-signatures/src/index.js
@@ -16,7 +16,13 @@ function prepForEncoding(ix) {
       sequenceNum: ix.accounts[ix.proposer].sequenceNum,
     },
     payer: ix.accounts[ix.payer].addr,
-    authorizers: ix.authorizations.map(cid => ix.accounts[cid].addr),
+    authorizers: ix.authorizations
+      .map(cid => ix.accounts[cid].addr)
+      .reduce((prev, current) => {
+        return prev.find(item => item === current)
+          ? prev
+          : [...prev, current]
+      }, []),
   }
 }
 

--- a/packages/send/src/send-transaction.js
+++ b/packages/send/src/send-transaction.js
@@ -19,7 +19,14 @@ export async function sendTransaction(ix, opts = {}) {
   tx.setReferenceBlockId(ix.message.refBlock ? hexBuffer(ix.message.refBlock) : null)
   tx.setPayer(addressBuffer(ix.accounts[ix.payer].addr))
   ix.message.arguments.forEach(arg => tx.addArguments(argumentBuffer(ix.arguments[arg].asArgument)))
-  ix.authorizations.forEach(tempId => tx.addAuthorizers(addressBuffer(ix.accounts[tempId].addr)))
+  ix.authorizations
+    .map(tempId => ix.accounts[tempId].addr)
+    .reduce((prev, current) => {
+      return prev.find(item => item === current)
+        ? prev
+        : [...prev, current]
+    }, [])
+    .forEach(addr => tx.addAuthorizers(addressBuffer(addr)))
 
   const proposalKey = new Transaction.ProposalKey()
   proposalKey.setAddress(addressBuffer(ix.accounts[ix.proposer].addr))


### PR DESCRIPTION
Currently for the case of multi-sig accounts, if we need multiple authorizer signatures from the same account, we need to do this:

```javascript
fcl.authorizations([
  authorization1, // acc1, key1
  authorization2, // acc1, key2
]),
```

but when the payload is encoded, it resolves into multiple authorizers with the same address
`authorizers:['acc1_address', 'acc1_address']`
and results in transaction failure

while it should be deduplicated into
`authorizers:['acc1_address']`

This PR fixes this issue.