### PR TITLE
Allow keyId to be mutated by actual signature

### DIFF
--- a/packages/sdk-resolve-signatures/src/__snapshots__/index.test.js.snap
+++ b/packages/sdk-resolve-signatures/src/__snapshots__/index.test.js.snap
@@ -6,6 +6,11 @@ Object {
     "foo": Object {
       "addr": "foo",
       "keyId": 0,
+      "role": Object {
+        "authorizer": true,
+        "payer": false,
+        "proposer": false,
+      },
       "sequenceNum": 0,
       "signature": "SIGNATURE",
       "signingFunction": [MockFunction] {
@@ -16,7 +21,11 @@ Object {
               "interaction": [Circular],
               "keyId": 0,
               "message": "f845f84283666f6fc0a000000000000000000000000000000000000000000000000000000000000000000a870000000000000f8080870000000000000fc8870000000000000fc0",
-              "roles": undefined,
+              "roles": Object {
+                "authorizer": true,
+                "payer": false,
+                "proposer": false,
+              },
             },
           ],
         ],

--- a/packages/sdk-resolve-signatures/src/index.js
+++ b/packages/sdk-resolve-signatures/src/index.js
@@ -41,7 +41,7 @@ async function fetchSignatures(ix, signers = [], message) {
       if (sansPrefix(ix.accounts[cid].addr) !== sansPrefix(compSig.addr)) {
         throw new Error(`${cid} — mismatching address in composite signature`)
       }
-      if (ix.accounts[cid].keyId !== compSig.keyId) {
+      if (ix.accounts[cid].role.proposer && ix.accounts[cid].keyId !== compSig.keyId) {
         throw new Error(`${cid} — mismatching keyId in composite signature`)
       }
       compSig.sig = compSig.signature
@@ -66,8 +66,12 @@ function collateSigners(ix) {
 }
 
 function mutateAccountsWithSignatures(ix, compSigs) {
-  for (let {cid, signature} of compSigs) {
+  for (let {cid, signature, keyId} of compSigs) {
     ix.accounts[cid].signature = signature
+
+    if (!ix.accounts[cid].role.proposer) {
+      ix.accounts[cid].keyId = keyId
+    }
   }
   return compSigs
 }

--- a/packages/sdk-resolve-signatures/src/index.test.js
+++ b/packages/sdk-resolve-signatures/src/index.test.js
@@ -24,6 +24,11 @@ test("Golden Path", async () => {
         keyId: 0,
         sequenceNum: 0,
         signingFunction: signingFunction,
+        role: {
+          proposer: false,
+          authorizer: true,
+          payer: false,
+        },
       },
     },
     proposer: "foo",


### PR DESCRIPTION
Only proposer keyId should be pre-defined before payload signatures.
For authorizer signatures, signers should be able to sign with any keys as long as the total weight is over 1000.
This PR removes the limit that authorizer keyId need to be known beforehand during the initial construction of the transaction, and use whatever signatures are actually provided.