### PR TITLE
add custom deployment scripts for six-set-code's template function

### DIFF
--- a/packages/six-set-code/src/six-set-code.js
+++ b/packages/six-set-code/src/six-set-code.js
@@ -12,8 +12,8 @@ export const CODE =
     }
 }`
 
-export const template = ({ proposer, authorization, payer, code = "" }) => sdk.pipe([
-    sdk.transaction(CODE),
+export const template = ({ proposer, authorization, payer, code = "", deployScript = CODE }) => sdk.pipe([
+    sdk.transaction(deployScript),
     sdk.args([sdk.arg(Buffer.from(code, "utf8").toString("hex"), t.String)]),
     sdk.proposer(proposer),
     sdk.authorizations([authorization]),


### PR DESCRIPTION
For new cadence contract deploy transaction , the package @onflow/six-set-code need to customize deploy code for 
```
acct.contracts.add(name: "HelloWorld", code: code.decodeHex())

```

so I prefer the deploy script can be customize for the user too, and keep the default CODE for downward compatibility