### PR TITLE
Updates for pre-auth - multiple keys from the same account

### DIFF
--- a/packages/fcl/src/temp.js
+++ b/packages/fcl/src/temp.js
@@ -219,6 +219,9 @@ function fetchSignature(ix, payload) {
     const {signature} = await acct.signingFunction(
       buildSignable(acct, payload, ix)
     )
+    if (!acct.role.proposer) {
+      ix.accounts[id].keyId = keyId
+    }
     ix.accounts[id].signature = signature
   }
 }


### PR DESCRIPTION
### 1. Fixes https://github.com/onflow/flow-js-sdk/issues/459.
For example, in the case that user requires authorization from 2 accounts `["account1", "account2"]` and `account1` requires 2 keys `["account1|0", "account1|2"]`, authorizers are mapped from 
```
["zxxsf8uvs7", "mf0v3p6t2c"]

->
["CURRENT_USER", "mf0v3p6t2c"]

->
[ ["0xd5f1a3954f06b231|0", "0xd5f1a3954f06b231|2"], "mf0v3p6t2c"]

->
["0xd5f1a3954f06b231|0", "0xd5f1a3954f06b231|2", "mf0v3p6t2c"]
```

### 2. Add back in #455 
Mutate key ID with the key ID from signature response.