### PR TITLE
Use keyID from signatures

### DIFF
--- a/packages/fcl/src/resolvers/resolve-signatures.js
+++ b/packages/fcl/src/resolvers/resolve-signatures.js
@@ -51,6 +51,9 @@ function fetchSignature(ix, payload) {
     const {signature} = await acct.signingFunction(
       buildSignable(acct, payload, ix)
     )
+    if (!acct.role.proposer) {
+      ix.accounts[id].keyId = keyId
+    }
     ix.accounts[id].signature = signature
   }
 }


### PR DESCRIPTION
This seems to be dropped accidentally during the cleanup! https://github.com/onflow/flow-js-sdk/commit/6e33da8627a6f2411d333aac7aa316200f3861e1