### PR TITLE
[sdk] Remove build-params and makeParams

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 
+- 2021-04-20 -- Removes **Deprecated** `params`, `buildParams`
+
 ### 0.0.45-alpha.20 -- 2021-04-21
 
 - 2021-04-21 -- **BREAKING** The experimental feature `sdk.meta` which allowed for a transaction to send along meta data to an authorization function has been removed because of the unprovable nature of its data and our strict trustless requirements. We believe this removal is in the best interest for js-sdk/fcl end users and will be looking into alternative approaches that provide the same functionality but in a more provable/trustless way. We have no ETA on this features replacement.

--- a/packages/sdk/src/build/build-params.js
+++ b/packages/sdk/src/build/build-params.js
@@ -1,9 +1,0 @@
-import {pipe, makeParam} from "../interaction/interaction.js"
-
-export function params(px = []) {
-  return pipe(px.map(makeParam))
-}
-
-export function param(value, xform = null, key = null) {
-  return {key, value, xform: null}
-}

--- a/packages/sdk/src/build/build-params.test.js
+++ b/packages/sdk/src/build/build-params.test.js
@@ -1,4 +1,0 @@
-test("placeholder", () => {
-    expect(0).toBe(0)
-})
-  

--- a/packages/sdk/src/interaction/interaction.js
+++ b/packages/sdk/src/interaction/interaction.js
@@ -176,20 +176,6 @@ export const prepAccount = (acct, opts = {}) => ix => {
   return ix
 }
 
-export const makeParam = param => ix => {
-  let tempId = uuid()
-  ix.message.params.push(tempId)
-
-  ix.params[tempId] = JSON.parse(PRM)
-  ix.params[tempId].tempId = tempId
-  ix.params[tempId].key = param.key
-  ix.params[tempId].value = param.value
-  ix.params[tempId].asParam = param.asParam
-  ix.params[tempId].xform = param.xform
-  ix.params[tempId].resolve = param.resolve
-  return Ok(ix)
-}
-
 export const makeArgument = arg => ix => {
   let tempId = uuid()
   ix.message.arguments.push(tempId)

--- a/packages/sdk/src/resolve/resolve-cadence.test.js
+++ b/packages/sdk/src/resolve/resolve-cadence.test.js
@@ -1,4 +1,4 @@
-import {interaction, pipe, put, makeScript, makeParam} from "../interaction/interaction.js"
+import {interaction, pipe, put, makeScript} from "../interaction/interaction.js"
 import {resolveCadence} from "./resolve-cadence.js"
 
 const log = msg => ix => (console.log(msg, ix), ix)

--- a/packages/sdk/src/sdk.js
+++ b/packages/sdk/src/sdk.js
@@ -1,3 +1,4 @@
+import {deprecate} from "./utils"
 // Base
 export {build} from "./build/build.js"
 export {resolve} from "./resolve/resolve.js"
@@ -54,7 +55,6 @@ export {getCollection} from "./build/build-get-collection"
 export {getTransactionStatus} from "./build/build-get-transaction-status.js"
 export {getTransaction} from "./build/build-get-transaction.js"
 export {limit} from "./build/build-limit.js"
-export {params, param} from "./build/build-params.js"
 export {args, arg} from "./build/build-arguments.js"
 export {proposer} from "./build/build-proposer.js"
 export {payer} from "./build/build-payer.js"
@@ -75,3 +75,17 @@ export {resolveParams} from "./resolve/resolve-params"
 
 // Config
 export {config} from "@onflow/config"
+
+// Deprecated
+export const params = params =>
+  deprecate.error({
+    name: "params",
+    transitionsPath:
+      "https://github.com/onflow/flow-js-sdk/blob/master/packages/sdk/TRANSITIONS.md#0001-deprecate-params",
+  })
+export const param = params =>
+  deprecate.warn({
+    name: "param",
+    transitionsPath:
+      "https://github.com/onflow/flow-js-sdk/blob/master/packages/sdk/TRANSITIONS.md#0001-deprecate-params",
+  })

--- a/packages/sdk/src/utils/index.js
+++ b/packages/sdk/src/utils/index.js
@@ -1,0 +1,36 @@
+const buildWarningMessage = ({name, transitionsPath}) => {
+  console.warn(
+    `
+    %cFCL/SDK Deprecation Notice
+    ============================
+    The ${name} builder has been deprecated and will be removed in future versions of the Flow JS-SDK/FCL.
+    You can learn more (including a guide on common transition paths) here: ${transitionsPath}
+    ============================
+  `,
+    "font-weight:bold;font-family:monospace;"
+  )
+}
+
+const buildErrorMessage = ({name, transitionsPath}) => {
+  console.error(
+    `
+    %cFCL/SDK Deprecation Notice
+    ============================
+    The ${name} builder has been removed from the Flow JS-SDK/FCL.
+    You can learn more (including a guide on common transition paths) here: ${transitionsPath}
+    ============================
+  `,
+    "font-weight:bold;font-family:monospace;"
+  )
+}
+
+const warn = deprecated => buildWarningMessage(deprecated)
+
+const error = deprecated => {
+  buildErrorMessage(deprecated)
+}
+
+export const deprecate = {
+  warn,
+  error,
+}


### PR DESCRIPTION
### Description
Remove files, functions, and references to params for deprecation.

- rm build-params.js
- delete makeParams from interaction
- remove exports from sdk/fcl
- clean up tests