### PR TITLE
[sdk] Add wallet-utils and validateSignableTransaction

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 
-- 2021-04-20 -- Removes **Deprecated** `params`, `buildParams`
+- 2021-04-22 -- Adds `wallet-utils` `validateSignableTransaction` support for wallets to validate Signable payload
+- 2021-04-21 -- Removes **Deprecated** `params`, `buildParams`
 - 2021-04-21 -- Updates encoding naming of `gasLimit` and `script` to `computeLimit` and `cadence`. Internal only.
 
 ### 0.0.45-alpha.20 -- 2021-04-21

--- a/packages/sdk/src/wallet-utils/index.js
+++ b/packages/sdk/src/wallet-utils/index.js
@@ -1,0 +1,1 @@
+export { default as validateSignableTransaction } from './validate-tx.js'

--- a/packages/sdk/src/wallet-utils/index.js
+++ b/packages/sdk/src/wallet-utils/index.js
@@ -1,1 +1,1 @@
-export { default as validateSignableTransaction } from './validate-tx.js'
+export {validateSignableTransaction} from "./validate-tx.js"

--- a/packages/sdk/src/wallet-utils/validate-tx.js
+++ b/packages/sdk/src/wallet-utils/validate-tx.js
@@ -1,0 +1,19 @@
+import {
+  encodeTransactionPayload as encodeInsideMessage,
+  encodeTransactionEnvelope as encodeOutsideMessage,
+} from "../encode/encode.js"
+import {invariant} from "@onflow/util-invariant"
+import {TRANSACTION} from "../interaction/interaction"
+
+const validateSignableTransaction = signable => {
+  invariant(
+    signable.interaction.tag === TRANSACTION,
+    "Signable payload must be transaction"
+  )
+
+  return signable.roles.payer
+    ? encodeOutsideMessage(signable.voucher) === signable.message
+    : encodeInsideMessage(signable.voucher) === signable.message
+}
+
+export default validateSignableTransaction

--- a/packages/sdk/src/wallet-utils/validate-tx.js
+++ b/packages/sdk/src/wallet-utils/validate-tx.js
@@ -3,15 +3,25 @@ import {
   encodeTransactionEnvelope as encodeOutsideMessage,
 } from "../encode/encode.js"
 import {invariant} from "@onflow/util-invariant"
-import {TRANSACTION} from "../interaction/interaction"
+
+const isPayer = signable => {
+  return signable.roles.payer
+}
+const getVoucher = signable => {
+  return signable.voucher
+}
+const getMessage = signable => {
+  return signable.message
+}
+
+const isExpectedMessage = signable => {
+  return isPayer(signable)
+    ? encodeOutsideMessage(getVoucher(signable)) === getMessage(signable)
+    : encodeInsideMessage(getVoucher(signable)) === getMessage(signable)
+}
 
 export const validateSignableTransaction = signable => {
-  invariant(
-    signable.interaction.tag === TRANSACTION,
-    "Signable payload must be transaction"
-  )
+  invariant(isExpectedMessage(signable), "Signable payload must be transaction")
 
-  return signable.roles.payer
-    ? encodeOutsideMessage(signable.voucher) === signable.message
-    : encodeInsideMessage(signable.voucher) === signable.message
+  return true
 }

--- a/packages/sdk/src/wallet-utils/validate-tx.js
+++ b/packages/sdk/src/wallet-utils/validate-tx.js
@@ -5,7 +5,7 @@ import {
 import {invariant} from "@onflow/util-invariant"
 import {TRANSACTION} from "../interaction/interaction"
 
-const validateSignableTransaction = signable => {
+export const validateSignableTransaction = signable => {
   invariant(
     signable.interaction.tag === TRANSACTION,
     "Signable payload must be transaction"
@@ -15,5 +15,3 @@ const validateSignableTransaction = signable => {
     ? encodeOutsideMessage(signable.voucher) === signable.message
     : encodeInsideMessage(signable.voucher) === signable.message
 }
-
-export default validateSignableTransaction

--- a/packages/sdk/src/wallet-utils/validate-tx.test.js
+++ b/packages/sdk/src/wallet-utils/validate-tx.test.js
@@ -1,0 +1,69 @@
+import {validateSignableTransaction} from "./"
+import {
+  encodeTransactionPayload as encodeInsideMessage,
+  encodeTransactionEnvelope as encodeOutsideMessage,
+} from "../encode/encode.js"
+
+const MESSAGE = {
+  script: "",
+  gasLimit: 156,
+  refBlock: "123",
+  arguments: [],
+  proposalKey: {address: "0x01", keyId: 1, sequenceNum: 123},
+  payer: "0x01",
+  authorizers: ["0x01"],
+  payloadSigs: [
+    {address: "0x01", keyId: 1, sig: "123"},
+    {address: "0x01", keyId: 1, sig: "123"},
+  ],
+}
+
+const encodedPayerMessage = encodeOutsideMessage(MESSAGE)
+
+const encodedNonPayerMessage = encodeInsideMessage(MESSAGE)
+
+const VOUCHER = {
+  script: "",
+  gasLimit: 156,
+  refBlock: "123",
+  arguments: [],
+  proposalKey: {address: "0x01", keyId: 1, sequenceNum: 123},
+  payer: "0x01",
+  authorizers: ["0x01"],
+  payloadSigs: [
+    {address: "0x01", keyId: 1, sig: "123"},
+    {address: "0x01", keyId: 1, sig: "123"},
+  ],
+}
+
+const PAYER_SIGNABLE = {
+  f_type: "Signable",
+  message: encodedPayerMessage,
+  roles: {proposer: false, authorizer: false, payer: true, param: false},
+  interaction: {
+    tag: "TRANSACTION",
+  },
+  voucher: VOUCHER,
+}
+
+const NON_PAYER_SIGNABLE = {
+  f_type: "Signable",
+  message: encodedNonPayerMessage,
+  roles: {proposer: true, authorizer: false, payer: false, param: false},
+  interaction: {
+    tag: "TRANSACTION",
+  },
+  voucher: VOUCHER,
+}
+
+describe("validate signable", () => {
+  test("validate payer tx in signable", () => {
+    const result = validateSignableTransaction(PAYER_SIGNABLE)
+    expect(result).toBe(true)
+  })
+
+  test("validate nonpayer tx in signable", () => {
+    const result = validateSignableTransaction(NON_PAYER_SIGNABLE)
+    expect(result).toBe(true)
+  })
+})

--- a/packages/sdk/src/wallet-utils/validate-tx.test.js
+++ b/packages/sdk/src/wallet-utils/validate-tx.test.js
@@ -5,8 +5,8 @@ import {
 } from "../encode/encode.js"
 
 const MESSAGE = {
-  script: "",
-  gasLimit: 156,
+  cadence: "",
+  computeLimit: 156,
   refBlock: "123",
   arguments: [],
   proposalKey: {address: "0x01", keyId: 1, sequenceNum: 123},
@@ -23,8 +23,8 @@ const encodedPayerMessage = encodeOutsideMessage(MESSAGE)
 const encodedNonPayerMessage = encodeInsideMessage(MESSAGE)
 
 const VOUCHER = {
-  script: "",
-  gasLimit: 156,
+  cadence: "",
+  computeLimit: 156,
   refBlock: "123",
   arguments: [],
   proposalKey: {address: "0x01", keyId: 1, sequenceNum: 123},


### PR DESCRIPTION
### Description

- Adds `sdk.wallet-utils.validateSignableTransaction` 
- Support for wallets to validate `Signable` transaction `message` against `voucher`