### PR TITLE
[sdkk] Update createSignableVoucher to match encoding fields check

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 - YYYY-MM-DD **BREAKING?** -- description
+- 2021-04-19 -- Internal only, update `voucher` fields to match message
 - 2021-04-15 -- Add `createSignableVoucher` for message payload verification by wallet, pass as `voucher` to `PreSignable` and `Signable`
 - 2021-04-15 -- Exposes `config` from SDK.
 - 2021-04-15 -- Removes use of `TextDecoder` from `send-get-account`.
@@ -10,7 +11,6 @@
 ### 0.0.45-alpha.18 -- 2021-04-09
 
 - 2021-04-08 -- Adds `GetCollection` interaction, build, send and decode support.
-- 2021-04-08 -- - Implements Transaction Metadata for media rich wallet transactions
 - 2021-04-08 -- Implements Transaction Metadata for media rich wallet transactions
   - Adds `metadata` field to `interaction` and provides `meta` builder to include optional metadata with the transaction.
   - `meta()` accepts the optional fields `title`, `description`, `price`, and `image` as Strings. Invalid types will `throw`. Unsupport fields will be scrubbed.

--- a/packages/sdk/src/interaction/interaction.js
+++ b/packages/sdk/src/interaction/interaction.js
@@ -302,9 +302,9 @@ export const destroy = key => ix => {
 
 export const createSignableVoucher = ix => {
   return {
-    cadence: ix.message.cadence,
+    script: ix.message.cadence,
+    gasLimit: ix.message.computeLimit,
     refBlock: ix.message.refBlock || null,
-    computeLimit: ix.message.computeLimit,
     arguments: ix.message.arguments.map(id => ix.arguments[id].asArgument),
     proposalKey: {
       address: withPrefix(ix.accounts[ix.proposer].addr),

--- a/packages/sdk/src/resolve/__snapshots__/resolve-signatures.test.js.snap
+++ b/packages/sdk/src/resolve/__snapshots__/resolve-signatures.test.js.snap
@@ -46,8 +46,7 @@ Object {
                 "authorizers": Array [
                   "0xfoo",
                 ],
-                "cadence": "",
-                "computeLimit": 156,
+                "gasLimit": 156,
                 "payer": "0xfoo",
                 "payloadSigs": Array [],
                 "proposalKey": Object {
@@ -56,6 +55,7 @@ Object {
                   "sequenceNum": 123,
                 },
                 "refBlock": "123",
+                "script": "",
               },
             },
           ],

--- a/packages/sdk/src/resolve/resolve-accounts.test.js
+++ b/packages/sdk/src/resolve/resolve-accounts.test.js
@@ -41,9 +41,9 @@ const IX = {
   payer: "f086a545ce3c552d|18",
   metadata: META,
   message: {
-    cadence: "",
+    script: "",
     refBlock: "123",
-    computeLimit: 156,
+    gasLimit: 156,
     proposer: null,
     payer: null,
     authorizations: [],
@@ -74,9 +74,9 @@ test("Voucher in PreSignable", async () => {
   const ps = buildPreSignable(ix.accounts[ix.proposer], ix)
 
   expect(ps.voucher).toEqual({
-    cadence: "",
+    script: "",
     refBlock: "123",
-    computeLimit: 156,
+    gasLimit: 156,
     arguments: [],
     proposalKey: {address: "0x01", keyId: 1, sequenceNum: 123},
     payer: "0x01",

--- a/packages/sdk/src/resolve/resolve-signatures.test.js
+++ b/packages/sdk/src/resolve/resolve-signatures.test.js
@@ -90,9 +90,9 @@ test("voucher in signable", async () => {
   const signable = buildSignable(ix.accounts[ix.proposer], {}, ix)
 
   expect(signable.voucher).toEqual({
-    cadence: "",
+    script: "",
     refBlock: "123",
-    computeLimit: 156,
+    gasLimit: 156,
     arguments: [],
     proposalKey: {address: "0x01", keyId: 1, sequenceNum: 123},
     payer: "0x01",


### PR DESCRIPTION
### Description

- encoding checks for the following payloadFields = [
  {name: "script", check: isString},
  {name: "arguments", check: isArray},
  {name: "refBlock", check: isString, defaultVal: "0"},
  {name: "gasLimit", check: isNumber},
  {name: "proposalKey", check: isObject},
  {name: "payer", check: isString},
  {name: "authorizers", check: isArray},
]
- Updated to match naming of `gasLimit` and `script`