### PR TITLE
[sdk] Move createVoucher to /utils

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 
+- 2021-04-23 -- Move `createVoucher` to `/utils` to resolve circular dependency in `interaction`
 - 2021-04-22 -- Adds `wallet-utils` `validateSignableTransaction` support for wallets to validate Signable payload
 - 2021-04-21 -- Removes **Deprecated** `params`, `buildParams`
 - 2021-04-21 -- Updates encoding naming of `gasLimit` and `script` to `computeLimit` and `cadence`. Internal only.

--- a/packages/sdk/src/interaction/interaction.js
+++ b/packages/sdk/src/interaction/interaction.js
@@ -1,6 +1,4 @@
 import {invariant} from "@onflow/util-invariant"
-import {withPrefix} from "@onflow/util-address"
-import {findInsideSigners} from "../resolve/resolve-signatures"
 
 export const UNKNOWN /*                       */ = "UNKNOWN"
 export const SCRIPT /*                        */ = "SCRIPT"
@@ -278,29 +276,4 @@ export const update = (key, fn = identity) => ix => {
 export const destroy = key => ix => {
   delete ix.assigns[key]
   return Ok(ix)
-}
-
-export const createSignableVoucher = ix => {
-  return {
-    cadence: ix.message.cadence,
-    refBlock: ix.message.refBlock || null,
-    computeLimit: ix.message.computeLimit,
-    arguments: ix.message.arguments.map(id => ix.arguments[id].asArgument),
-    proposalKey: {
-      address: withPrefix(ix.accounts[ix.proposer].addr),
-      keyId: ix.accounts[ix.proposer].keyId,
-      sequenceNum: ix.accounts[ix.proposer].sequenceNum,
-    },
-    payer: withPrefix(ix.accounts[ix.payer].addr),
-    authorizers: ix.authorizations
-      .map(cid => withPrefix(ix.accounts[cid].addr))
-      .reduce((prev, current) => {
-        return prev.find(item => item === current) ? prev : [...prev, current]
-      }, []),
-    payloadSigs: findInsideSigners(ix).map(id => ({
-      address: withPrefix(ix.accounts[id].addr),
-      keyId: ix.accounts[id].keyId,
-      sig: ix.accounts[id].signature,
-    })),
-  }
 }

--- a/packages/sdk/src/resolve/resolve-accounts.js
+++ b/packages/sdk/src/resolve/resolve-accounts.js
@@ -1,8 +1,6 @@
 import {invariant} from "@onflow/util-invariant"
-import {
-  isTransaction,
-  createSignableVoucher,
-} from "../interaction/interaction.js"
+import {isTransaction} from "../interaction/interaction.js"
+import {createVoucher} from "../utils"
 
 const isFn = v => typeof v === "function"
 export function buildPreSignable(acct, ix) {
@@ -15,7 +13,7 @@ export function buildPreSignable(acct, ix) {
       args: ix.message.arguments.map(d => ix.arguments[d].asArgument),
       data: {},
       interaction: ix,
-      voucher: createSignableVoucher(ix),
+      voucher: createVoucher(ix),
     }
   } catch (error) {
     console.error("buildPreSignable", error)

--- a/packages/sdk/src/resolve/resolve-signatures.js
+++ b/packages/sdk/src/resolve/resolve-signatures.js
@@ -1,7 +1,5 @@
-import {
-  isTransaction,
-  createSignableVoucher,
-} from "../interaction/interaction.js"
+import {isTransaction} from "../interaction/interaction.js"
+import {createVoucher} from "../utils"
 import {sansPrefix} from "@onflow/util-address"
 import {
   encodeTransactionPayload as encodeInsideMessage,
@@ -74,7 +72,7 @@ export function buildSignable(acct, message, ix) {
       args: ix.message.arguments.map(d => ix.arguments[d].asArgument),
       data: {},
       interaction: ix,
-      voucher: createSignableVoucher(ix),
+      voucher: createVoucher(ix),
     }
   } catch (error) {
     console.error("buildSignable", error)

--- a/packages/sdk/src/utils/create-voucher.js
+++ b/packages/sdk/src/utils/create-voucher.js
@@ -1,0 +1,26 @@
+import {withPrefix} from "@onflow/util-address"
+import {findInsideSigners} from "../resolve/resolve-signatures"
+export const createVoucher = ix => {
+  return {
+    cadence: ix.message.cadence,
+    refBlock: ix.message.refBlock || null,
+    computeLimit: ix.message.computeLimit,
+    arguments: ix.message.arguments.map(id => ix.arguments[id].asArgument),
+    proposalKey: {
+      address: withPrefix(ix.accounts[ix.proposer].addr),
+      keyId: ix.accounts[ix.proposer].keyId,
+      sequenceNum: ix.accounts[ix.proposer].sequenceNum,
+    },
+    payer: withPrefix(ix.accounts[ix.payer].addr),
+    authorizers: ix.authorizations
+      .map(cid => withPrefix(ix.accounts[cid].addr))
+      .reduce((prev, current) => {
+        return prev.find(item => item === current) ? prev : [...prev, current]
+      }, []),
+    payloadSigs: findInsideSigners(ix).map(id => ({
+      address: withPrefix(ix.accounts[id].addr),
+      keyId: ix.accounts[id].keyId,
+      sig: ix.accounts[id].signature,
+    })),
+  }
+}

--- a/packages/sdk/src/utils/index.js
+++ b/packages/sdk/src/utils/index.js
@@ -1,3 +1,5 @@
+export {createVoucher} from "./create-voucher.js"
+
 const buildWarningMessage = ({name, transitionsPath}) => {
   console.warn(
     `


### PR DESCRIPTION
### Description

- Move/rename `createVoucher` to /utils to resolve circular dependency in `interaction`