### PR TITLE
[sdk] Adds TRANSACTION_DOMAIN_TAG check to validate signable in wallet utils

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -29,6 +29,7 @@
 <br>
 <br>
 <br>
+- 2021-05-28 -- Includes check for new TRANSACTION_DOMAIN_TAG in wallet/utils `validateSignableTransaction`
 
 ## 0.0.47-alpha.1 - 2021-05-27
 

--- a/packages/sdk/src/encode/encode.js
+++ b/packages/sdk/src/encode/encode.js
@@ -9,7 +9,7 @@ const rightPaddedHexBuffer = (value, pad) =>
 const leftPaddedHexBuffer = (value, pad) =>
   Buffer.from(value.padStart(pad * 2, 0), "hex")
 
-const TRANSACTION_DOMAIN_TAG = rightPaddedHexBuffer(Buffer.from("FLOW-V0.0-transaction").toString("hex"), 32).toString("hex")
+export const TRANSACTION_DOMAIN_TAG = rightPaddedHexBuffer(Buffer.from("FLOW-V0.0-transaction").toString("hex"), 32).toString("hex")
 const prependTransactionDomainTag = tx => TRANSACTION_DOMAIN_TAG + tx
 
 const addressBuffer = addr => leftPaddedHexBuffer(addr, 8)

--- a/packages/sdk/src/wallet-utils/validate-tx.js
+++ b/packages/sdk/src/wallet-utils/validate-tx.js
@@ -1,4 +1,5 @@
 import {
+  TRANSACTION_DOMAIN_TAG,
   encodeTransactionPayload as encodeInsideMessage,
   encodeTransactionEnvelope as encodeOutsideMessage,
 } from "../encode/encode.js"
@@ -7,11 +8,17 @@ import {invariant} from "@onflow/util-invariant"
 const isPayer = signable => {
   return signable.roles.payer
 }
+
 const getVoucher = signable => {
   return signable.voucher
 }
+
 const getMessage = signable => {
   return signable.message
+}
+
+const getDomainTag = signable => {
+  return getMessage(signable).substring(0, TRANSACTION_DOMAIN_TAG.length)
 }
 
 const isExpectedMessage = signable => {
@@ -20,8 +27,20 @@ const isExpectedMessage = signable => {
     : encodeInsideMessage(getVoucher(signable)) === getMessage(signable)
 }
 
+const isTransaction = signable => {
+  return getDomainTag(signable) === TRANSACTION_DOMAIN_TAG
+}
+
 export const validateSignableTransaction = signable => {
-  invariant(isExpectedMessage(signable), "Signable payload must be transaction")
+  invariant(
+    isTransaction(signable),
+    "Signable payload must be a valid transaction"
+  )
+
+  invariant(
+    isExpectedMessage(signable),
+    "Signable payload does not match expected"
+  )
 
   return true
 }


### PR DESCRIPTION
### Description

- Updates `validateSignableTransaction` to integrate **TRANSACTION_DOMAIN_TAG**
- Validates that the message to be signed is a valid transaction
