### PR TITLE
Tiny fix: Update README.md readability on NPM

### DIFF
--- a/packages/fcl/README.md
+++ b/packages/fcl/README.md
@@ -1,7 +1,5 @@
----
-title: FCL
-description: Making secure web applications powered by the Flow Blockchain
----
+# FCL: Flow Client Library
+### Making secure web applications powered by the Flow Blockchain
 
 Flow Client Library (FCL) enables applications to easily integrate with all FCL-compatible wallets and
 other services (e.g. (Comming Soon) profiles, private information, notifications). This offers developers a strong


### PR DESCRIPTION
Currently the table format that is read by github does not show up on NPM (https://www.npmjs.com/package/@onflow/fcl) and makes it look weird. This would fix that but unsure if this violating any standard format.

Changes:
---
title: FCL
description: Making secure web applications powered by the Flow Blockchain
---

to

# FCL: Flow Client Library
### Making secure web applications powered by the Flow Blockchain