### PR TITLE
[fcl] Updates serialize to return serialized voucher

### DIFF
--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 - YYYY-MM-DD **BREAKING?** -- description
+
+- 2021-05-27 -- Updates `fcl.serialize` to return serialized voucher
 - 2021-05-27 -- VSN `@onflow/sdk` 0.0.46-alpha.1 -> 0.0.47-alpha.1
 
 ## 0.0.70 - 2021-05-10

--- a/packages/fcl/src/fcl.test.js
+++ b/packages/fcl/src/fcl.test.js
@@ -1,6 +1,18 @@
 import * as fcl from "./fcl"
 import fs from "fs"
 import path from "path"
+import {serialize} from "./serialize"
+import {
+  resolve,
+  build,
+  transaction,
+  limit,
+  proposer,
+  authorizations,
+  payer,
+  ref,
+  createSignableVoucher,
+} from "@onflow/sdk"
 
 test("config", async () => {
   const $ = fcl.config()
@@ -8,6 +20,61 @@ test("config", async () => {
 })
 
 test("fcl.VERSION needs to match version in package.json", () => {
-  const pkg = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), "package.json"), "utf-8"))
+  const pkg = JSON.parse(
+    fs.readFileSync(path.resolve(process.cwd(), "package.json"), "utf-8")
+  )
   expect(pkg.version).toBe(fcl.VERSION)
+})
+
+test("serialize returns voucher", async () => {
+  const authz = {
+    addr: "0x01",
+    signingFunction: () => ({signature: "123"}),
+    keyId: 1,
+    sequenceNum: 123,
+  }
+
+  const serializedVoucher = JSON.stringify(
+    {
+      cadence: "",
+      refBlock: "123",
+      computeLimit: 156,
+      arguments: [],
+      proposalKey: {
+        address: "0x01",
+        keyId: 1,
+        sequenceNum: 123,
+      },
+      payer: "0x01",
+      authorizers: ["0x01"],
+      payloadSigs: [
+        {
+          address: "0x01",
+          keyId: 1,
+          sig: "123",
+        },
+        {
+          address: "0x01",
+          keyId: 1,
+          sig: "123",
+        },
+      ],
+    },
+    null,
+    2
+  )
+
+  const serializedIx = await serialize(
+    [
+      transaction``,
+      limit(156),
+      proposer(authz),
+      authorizations([authz]),
+      payer(authz),
+      ref("123"),
+    ],
+    {resolve}
+  )
+
+  expect(serializedIx).toEqual(serializedVoucher)
 })

--- a/packages/fcl/src/serialize/index.js
+++ b/packages/fcl/src/serialize/index.js
@@ -1,5 +1,6 @@
 import {interaction, pipe} from "@onflow/sdk"
 import {resolve as defaultResolve} from "@onflow/sdk"
+import {createSignableVoucher} from "@onflow/sdk"
 import {config} from "@onflow/config"
 
 export const serialize = async (args = [], opts = {}) => {
@@ -8,5 +9,10 @@ export const serialize = async (args = [], opts = {}) => {
     .get("sdk.resolve", opts.resolve || defaultResolve(opts))
 
   if (Array.isArray(args)) args = await pipe(interaction(), args)
-  return JSON.stringify(await resolveFunction(args), null, 2)
+
+  return JSON.stringify(
+    createSignableVoucher(await resolveFunction(args)),
+    null,
+    2
+  )
 }


### PR DESCRIPTION
### Description

- Exposes `createSignableVoucher` from `sdk`
- Updates `serialize` to return serialized `voucher` instead of `interaction`