### PR TITLE
[sdk] -- Adds ability to specify optional grpc metadata to requests sent to an Access API

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -15,8 +15,17 @@
 
 [@JeffreyDoyle](https://github.com/JeffreyDoyle):
 
+<br> 2021-06-16 -- [@JeffreyDoyle](https://github.com/JeffreyDoyle): Adds ability to specify optional grpc metadata to requests sent to an Access API. To specity grpc metadata, use config like such:
+
+```javascript
+import {config} from "@onflow/config"
+
+fcl.config()
+  .put("grpc.metadata", {"headerkey1": "headervalue1"})
+
+```
+
 <br> 2021-06-16 -- [@JeffreyDoyle](https://github.com/JeffreyDoyle): Adds encode signable wallet utility function.
-<br>
 <br>
 <br>
 <br>

--- a/packages/sdk/src/send/unary.js
+++ b/packages/sdk/src/send/unary.js
@@ -1,13 +1,16 @@
 import {grpc} from "@improbable-eng/grpc-web"
 import {NodeHttpTransport} from "@improbable-eng/grpc-web-node-http-transport"
+import {config} from "@onflow/config"
 
 grpc.setDefaultTransport(NodeHttpTransport())
 
 export async function unary(host, method, request) {
+  const metadataFromConfig = await config().get("grpc.metadata", {})
   return new Promise((resolve, reject) => {
     grpc.unary(method, {
       request: request,
       host: host,
+      metadata: new grpc.Metadata(metadataFromConfig),
       onEnd: ({status, statusMessage, message}) => {
         if (status === grpc.Code.OK) {
           resolve(message)


### PR DESCRIPTION
[sdk] -- Adds ability to specify optional grpc metadata to requests sent to an Access API