### PR TITLE
[fcl] Add verifyUserSignatures util to currentUser

### DIFF
--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 
-- 2021-07-07 -- Updates `composite-signature` normalizer to accept `Array` of composite signatures
+- 2021-07-07 -- Move `composite-signature` normalization to `current-user`
 - 2021-06-30 -- Updates `fcl.serialize` to fix setting `resolveFunction`
 
 ## 0.0.73 - 2021-06-21

--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 
-- 2021-07-07 -- Move `composite-signature` normalization to `current-user`
+- 2021-07-08 -- Adds `verifyUserSignatures` util to `currentUser()` and refines use of `composite-signature` normalization
 - 2021-06-30 -- Updates `fcl.serialize` to fix setting `resolveFunction`
 
 ## 0.0.73 - 2021-06-21

--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 
+- 2021-07-07 -- Updates `composite-signature` normalizer to accept `Array` of composite signatures
 - 2021-06-30 -- Updates `fcl.serialize` to fix setting `resolveFunction`
 
 ## 0.0.73 - 2021-06-21

--- a/packages/fcl/src/current-user/exec-service/strategies/http-post.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/http-post.js
@@ -1,7 +1,6 @@
 import {fetchService} from "./utils/fetch-service"
 import {serviceEndpoint} from "./utils/service-endpoint"
 import {normalizePollingResponse} from "../../normalize/polling-response"
-import {normalizeCompositeSignature} from "../../normalize/composite-signature"
 import {frame} from "./utils/frame"
 import {poll} from "./utils/poll"
 
@@ -26,7 +25,7 @@ export async function execHttpPost(service, signable, opts) {
     return poll(resp.updates, () => canContinue)
       .then(compositeSignature => {
         closeFrame()
-        return normalizeCompositeSignature(compositeSignature)
+        return compositeSignature
       })
       .catch(error => {
         console.error(error)

--- a/packages/fcl/src/current-user/exec-service/strategies/http-post.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/http-post.js
@@ -23,9 +23,9 @@ export async function execHttpPost(service, signable, opts) {
     })
 
     return poll(resp.updates, () => canContinue)
-      .then(compositeSignature => {
+      .then(serviceResponse => {
         closeFrame()
-        return compositeSignature
+        return serviceResponse
       })
       .catch(error => {
         console.error(error)

--- a/packages/fcl/src/current-user/exec-service/strategies/iframe-rpc.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/iframe-rpc.js
@@ -1,7 +1,6 @@
 import {uid} from "@onflow/util-uid"
 import {frame} from "./utils/frame"
 import {normalizePollingResponse} from "../../normalize/polling-response"
-import {normalizeCompositeSignature} from "../../normalize/composite-signature"
 
 export function execIframeRPC(service, body, opts) {
   return new Promise((resolve, reject) => {
@@ -41,7 +40,7 @@ export function execIframeRPC(service, body, opts) {
 
           switch (resp.status) {
             case "APPROVED":
-              resolve(normalizeCompositeSignature(resp.data))
+              resolve(resp.data)
               close()
               break
 
@@ -70,7 +69,7 @@ export function execIframeRPC(service, body, opts) {
 
           switch (resp.status) {
             case "APPROVED":
-              resolve(normalizeCompositeSignature(resp.data))
+              resolve(resp.data)
               close()
               break
 

--- a/packages/fcl/src/current-user/index.js
+++ b/packages/fcl/src/current-user/index.js
@@ -259,12 +259,97 @@ async function signUserMessage(msg, opts = {}) {
   }
 }
 
+const VERIFY_SIG_SCRIPT = `
+import Crypto
+    
+pub fun main(
+  message: String,
+  rawPublicKeys: [String],
+  weights: [UFix64],
+  signatures: [String],
+): Bool {
+
+  let keyList = Crypto.KeyList()
+  
+  var i = 0
+  for rawPublicKey in rawPublicKeys {
+    keyList.add(
+      PublicKey(
+        publicKey: rawPublicKey.decodeHex(),
+        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+      ),
+      hashAlgorithm: HashAlgorithm.SHA3_256,
+      weight: weights[i],
+    )
+    i = i + 1
+  }
+
+  let signatureSet: [Crypto.KeyListSignature] = []
+
+  var j = 0
+  for signature in signatures {
+    signatureSet.append(
+      Crypto.KeyListSignature(
+        keyIndex: j,
+        signature: signature.decodeHex()
+      )
+    )
+    j = j + 1
+  }
+    
+  let signedData = message.decodeHex()
+  
+  return keyList.verify(
+    signatureSet: signatureSet,
+    signedData: signedData
+  )
+}
+`
+
+async function verifyUserSignatures(msg, compSigs) {
+  invariant(/^[0-9a-f]+$/i.test(msg), "Message must be a hex string")
+  invariant(
+    Array.isArray(compSigs),
+    "Must include an Array of composite signatures"
+  )
+
+  let weights = []
+  let signatures = []
+  const rawPubKeys = await Promise.all(
+    compSigs.map(async cs => {
+      invariant(typeof cs.addr === "string", "addr must be a string")
+      invariant(typeof cs.keyId === "number", "keyId must be a number")
+      invariant(typeof cs.signature === "string", "signature must be a string")
+
+      try {
+        const account = await fcl.account(cs.addr)
+        weights.push(account.keys[cs.keyId].weight.toFixed(1))
+        signatures.push(cs.signature)
+        return account.keys[cs.keyId].publicKey
+      } catch (err) {
+        throw err
+      }
+    })
+  )
+
+  return await fcl.query({
+    cadence: `${VERIFY_SIG_SCRIPT}`,
+    args: (arg, t) => [
+      arg(msg, t.String),
+      arg(rawPubKeys, t.Array([t.String])),
+      arg(weights, t.Array(t.UFix64)),
+      arg(signatures, t.Array([t.String])),
+    ],
+  })
+}
+
 export const currentUser = () => {
   return {
     authenticate,
     unauthenticate,
     authorization,
     signUserMessage,
+    verifyUserSignatures,
     subscribe,
     snapshot,
   }

--- a/packages/fcl/src/current-user/normalize/composite-signature.js
+++ b/packages/fcl/src/current-user/normalize/composite-signature.js
@@ -10,8 +10,9 @@ import {sansPrefix} from "@onflow/util-address"
 // }
 export function normalizeCompositeSignature(resp) {
   if (resp == null) return null
+  if (Array.isArray(resp) && resp.length === 0) return null
 
-  switch (resp["f_vsn"]) {
+  switch (resp["f_vsn"] || resp[0]["f_vsn"]) {
     case "1.0.0":
       return resp
 

--- a/packages/fcl/src/current-user/normalize/composite-signature.js
+++ b/packages/fcl/src/current-user/normalize/composite-signature.js
@@ -10,9 +10,8 @@ import {sansPrefix} from "@onflow/util-address"
 // }
 export function normalizeCompositeSignature(resp) {
   if (resp == null) return null
-  if (Array.isArray(resp) && resp.length === 0) return null
 
-  switch (resp["f_vsn"] || resp[0]["f_vsn"]) {
+  switch (resp["f_vsn"]) {
     case "1.0.0":
       return resp
 


### PR DESCRIPTION
### Description
`verifyUserSignatures` returns true if the given signatures are valid for the given signed data

- Adds `verifyUserSignatures` util to `currentUser()` 
- Refines use of `composite-signature` normalization