### PR TITLE
Fix request logic in sendGetEvents

### DIFF
--- a/packages/sdk/src/send/send-get-events.js
+++ b/packages/sdk/src/send/send-get-events.js
@@ -14,7 +14,7 @@ async function getEventsForHeightRange(eventType, start, end, opts) {
 
   req.setType(eventType)
   req.setStartHeight(start)
-  req.seQtEndHeight(end)
+  req.setEndHeight(end)
 
   const res = unary(opts.node, AccessAPI.GetEventsForHeightRange, req)
 

--- a/packages/sdk/src/send/send-get-events.js
+++ b/packages/sdk/src/send/send-get-events.js
@@ -7,7 +7,7 @@ const hexBuffer = hex => Buffer.from(hex, "hex")
 const isHeightRangeRequest = ix => "start" in ix.events
 const isBlockIdsRequest = ix => "blockIds" in ix.events
 
-async function getEventsForHeightRange(eventType, start, end, opts) {
+async function getEventsForHeightRange(eventType, start, end, opts, tag) {
   const unary = opts.unary || defaultUnary
 
   const req = new GetEventsForHeightRangeRequest()
@@ -18,10 +18,10 @@ async function getEventsForHeightRange(eventType, start, end, opts) {
 
   const res = unary(opts.node, AccessAPI.GetEventsForHeightRange, req)
 
-  return formatResponse(res)
+  return formatResponse(res, tag)
 }
 
-async function getEventsForBlockIDs(eventType, blockIds, opts) {
+async function getEventsForBlockIDs(eventType, blockIds, opts, tag) {
   const unary = opts.unary || defaultUnary
 
   const req = new GetEventsForBlockIDsRequest()
@@ -34,12 +34,12 @@ async function getEventsForBlockIDs(eventType, blockIds, opts) {
 
   const res = await unary(opts.node, AccessAPI.GetEventsForBlockIDs, req)
 
-  return formatResponse(res)
+  return formatResponse(res, tag)
 }
 
-function formatResponse(res) {
-  let ret = response()
-  ret.tag = ix.tag
+function formatResponse(res, tag) {
+  const ret = response()
+  ret.tag = tag
 
   const results = res.getResultsList()
   ret.events = results.reduce((blocks, result) => {
@@ -74,6 +74,7 @@ export async function sendGetEvents(ix, opts = {}) {
       Number(ix.events.start),
       Number(ix.events.end),
       opts,
+      ix.tag,
     )
   }
 
@@ -82,6 +83,7 @@ export async function sendGetEvents(ix, opts = {}) {
       ix.events.eventType,
       ix.events.blockIds,
       opts,
+      ix.tag,
     )
   }
 

--- a/packages/sdk/src/send/send-get-events.js
+++ b/packages/sdk/src/send/send-get-events.js
@@ -4,8 +4,8 @@ import {unary as defaultUnary} from "./unary"
 
 const u8ToHex = u8 => Buffer.from(u8).toString("hex")
 const hexBuffer = hex => Buffer.from(hex, "hex")
-const isHeightRangeRequest = ix => "start" in ix.events
-const isBlockIdsRequest = ix => "blockIds" in ix.events
+const isHeightRangeRequest = ix => ix.events.start !== null
+const isBlockIdsRequest = ix => !!ix.events.blockIds
 
 async function getEventsForHeightRange(eventType, start, end, opts, tag) {
   const unary = opts.unary || defaultUnary


### PR DESCRIPTION
This line is incorrectly classifying the interaction as a block ID request when `events.start == 0`, which is a valid block height on the emulator:

```js
const req = ix.events.start ? new GetEventsForHeightRangeRequest() : new GetEventsForBlockIDsRequest()
```

This PR updates logic that decides which request to make.