### PR TITLE
[fcl] Update serialize to use new config util

### DIFF
--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 
+- 2021-06-30 -- Updates `fcl.serialize` to use new `config.first`
+
 ## 0.0.74-alpha.1
 
 - 2021-07-13 -- VSN `@onflow/sdk` 0.0.50 -> 0.0.51-alpha.1

--- a/packages/fcl/src/current-user/index.js
+++ b/packages/fcl/src/current-user/index.js
@@ -104,7 +104,10 @@ async function authenticate(opts = {}) {
 
     serviceStrategy(
       {
-        endpoint: config.first(["discovery.wallet", "challenge.handshake"]),
+        endpoint: await config.first([
+          "discovery.wallet",
+          "challenge.handshake",
+        ]),
       },
       {
         async onReady(e, {send, close}) {

--- a/packages/fcl/src/serialize/index.js
+++ b/packages/fcl/src/serialize/index.js
@@ -3,12 +3,11 @@ import {resolve as defaultResolve} from "@onflow/sdk"
 import {config, createSignableVoucher} from "@onflow/sdk"
 
 export const serialize = async (args = [], opts = {}) => {
-  // prettier-ignore
-  const resolveFunction = await config().get(
-    "sdk.resolve",
+  const resolveFunction = await config.first(
+    ["sdk.resolve"],
     opts.resolve || defaultResolve
   )
-  
+
   if (Array.isArray(args)) args = await pipe(interaction(), args)
 
   return JSON.stringify(


### PR DESCRIPTION
- Add missing `await` on auth endpoint config
- Update `fcl.serialize` to use new config.first in setting `resolveFunction`