### PR TITLE
[sdk] -- Refactors Send Functions to prevent and mitigate cases where the expected request type cannot be determined.

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 - YYYY-MM-DD **BREAKING?** -- Who: description
+- 2021-07-14 -- [@JeffreyDoyle](https://github.com/JeffreyDoyle): Refactors Send Functions to prevent and mitigate cases where the expected request type cannot be determined.
 
 ## 0.0.51 -- 2021-07-20
 

--- a/packages/sdk/src/send/send-execute-script.js
+++ b/packages/sdk/src/send/send-execute-script.js
@@ -40,13 +40,13 @@ async function sendExecuteScriptAtBlockHeightRequest(ix, opts) {
 async function sendExecuteScriptAtLatestBlockRequest(ix, opts) {
   const unary = opts.unary || defaultUnary
 
-  let req = new ExecuteScriptAtLatestBlockRequest()
+  const req = new ExecuteScriptAtLatestBlockRequest()
   
   const code = Buffer.from(ix.message.cadence, "utf8")
   ix.message.arguments.forEach(arg => req.addArguments(argumentBuffer(ix.arguments[arg].asArgument)))
   req.setScript(code)
 
-  let res = await unary(opts.node, AccessAPI.ExecuteScriptAtLatestBlock, req)
+  const res = await unary(opts.node, AccessAPI.ExecuteScriptAtLatestBlock, req)
 
   return constructResponse(ix, res)
 }

--- a/packages/sdk/src/send/send-execute-script.js
+++ b/packages/sdk/src/send/send-execute-script.js
@@ -8,7 +8,7 @@ const hexBuffer = hex => Buffer.from(hex, "hex")
 async function sendExecuteScriptAtBlockIDRequest(ix, opts) {
   const unary = opts.unary || defaultUnary
 
-  let req = new ExecuteScriptAtBlockIDRequest()
+  const req = new ExecuteScriptAtBlockIDRequest()
 
   req.setBlockId(hexBuffer(ix.block.id))
 
@@ -16,7 +16,7 @@ async function sendExecuteScriptAtBlockIDRequest(ix, opts) {
   ix.message.arguments.forEach(arg => req.addArguments(argumentBuffer(ix.arguments[arg].asArgument)))
   req.setScript(code)
 
-  let res = await unary(opts.node, AccessAPI.ExecuteScriptAtBlockID, req)
+  const res = await unary(opts.node, AccessAPI.ExecuteScriptAtBlockID, req)
 
   return constructResponse(ix, res)
 }
@@ -24,7 +24,7 @@ async function sendExecuteScriptAtBlockIDRequest(ix, opts) {
 async function sendExecuteScriptAtBlockHeightRequest(ix, opts) {
   const unary = opts.unary || defaultUnary
 
-  let req = new ExecuteScriptAtBlockHeightRequest()
+  const req = new ExecuteScriptAtBlockHeightRequest()
 
   req.setBlockHeight(Number(ix.block.height))
 
@@ -32,7 +32,7 @@ async function sendExecuteScriptAtBlockHeightRequest(ix, opts) {
   ix.message.arguments.forEach(arg => req.addArguments(argumentBuffer(ix.arguments[arg].asArgument)))
   req.setScript(code)
 
-  let res = await unary(opts.node, AccessAPI.ExecuteScriptAtBlockHeight, req) 
+  const res = await unary(opts.node, AccessAPI.ExecuteScriptAtBlockHeight, req) 
   
   return constructResponse(ix, res)
 }

--- a/packages/sdk/src/send/send-execute-script.test.js
+++ b/packages/sdk/src/send/send-execute-script.test.js
@@ -19,11 +19,13 @@ describe("Send Execute Script", () => {
   test("ExecuteScriptAtLatestBlock", async () => {
     const unaryMock = jest.fn();
 
+    const returnedJSONCDC = {type: "Int", value: 123}
+
     unaryMock.mockReturnValue({
-        getValue_asU8: () => jsonToUInt8Array({type: "Int", value: 123})
+        getValue_asU8: () => jsonToUInt8Array(returnedJSONCDC)
     });
 
-    await sendExecuteScript(
+    let response = await sendExecuteScript(
         await resolve(
             await build([
                 script`pub fun main(): Int { return 123 }`
@@ -48,16 +50,20 @@ describe("Send Execute Script", () => {
     const unaryMockScript = unaryMockRequest.getScript()
 
     expect(unaryMockScript).not.toBeUndefined()
+
+    expect(response.encodedData).toEqual(returnedJSONCDC)
   })
 
   test("ExecuteScriptAtBlockID", async () => {
     const unaryMock = jest.fn();
 
+    const returnedJSONCDC = {type: "Int", value: 123}
+
     unaryMock.mockReturnValue({
-        getValue_asU8: () => jsonToUInt8Array({type: "Int", value: 123})
+        getValue_asU8: () => jsonToUInt8Array(returnedJSONCDC)
     });
 
-    await sendExecuteScript(
+    const response = await sendExecuteScript(
         await resolve(
             await build([
                 script`pub fun main(): Int { return 123 }`,
@@ -85,16 +91,20 @@ describe("Send Execute Script", () => {
 
     expect(unaryMockScript).not.toBeUndefined()
     expect(unaryMockBlockID).not.toBeUndefined()
+
+    expect(response.encodedData).toEqual(returnedJSONCDC)
   })
 
   test("ExecuteScriptAtBlockHeight", async () => {
     const unaryMock = jest.fn();
 
+    const returnedJSONCDC = {type: "Int", value: 123}
+
     unaryMock.mockReturnValue({
-        getValue_asU8: () => jsonToUInt8Array({type: "Int", value: 123})
+        getValue_asU8: () => jsonToUInt8Array(returnedJSONCDC)
     });
 
-    await sendExecuteScript(
+    const response = await sendExecuteScript(
         await resolve(
             await build([
                 script`pub fun main(): Int { return 123 }`,
@@ -122,6 +132,8 @@ describe("Send Execute Script", () => {
 
     expect(unaryMockScript).not.toBeUndefined()
     expect(unaryMockBlockHeight).not.toBeUndefined()
+
+    expect(response.encodedData).toEqual(returnedJSONCDC)
   })
 
 })

--- a/packages/sdk/src/send/send-get-account.js
+++ b/packages/sdk/src/send/send-get-account.js
@@ -30,7 +30,7 @@ async function sendGetAccountAtLatestBlockRequest(ix, opts) {
   return constructResponse(ix, res)
 }
 
-function constructResponse(res, ix) {
+function constructResponse(ix, res) {
   let ret = response()
   ret.tag = ix.tag
 

--- a/packages/sdk/src/send/send-get-account.test.js
+++ b/packages/sdk/src/send/send-get-account.test.js
@@ -14,14 +14,34 @@ const jsonToUInt8Array = (json) => {
     return ret
 };
 
+const hexStrToUInt8Array = (hex) => {
+    return new Uint8Array(hex.match(/.{1,2}/g).map(byte => parseInt(byte, 16)));
+};
+
+const strToUInt8Array = (str) => {
+    var ret = new Uint8Array(str.length);
+    for (var i = 0; i < str.length; i++) {
+        ret[i] = str.charCodeAt(i);
+    }
+    return ret
+};
+
 describe("Send Get Account", () => {
   test("GetAccountAtBlockHeightRequest", async () => {
     const unaryMock = jest.fn();
 
+    const returnedAccount = {
+        address: "0x1654653399040a61",
+        code: "contract",
+        keys: [],
+        balance: 10,
+        contracts: {}
+    }
+
     unaryMock.mockReturnValue({
         getAccount: () => ({
-            getAddress_asU8: () => jsonToUInt8Array({type: "Address", value: "0xABC123"}),
-            getCode_asU8: () => jsonToUInt8Array({type: "String", value: "contract"}),
+            getAddress_asU8: () => hexStrToUInt8Array("1654653399040a61"),
+            getCode_asU8: () => strToUInt8Array("contract"),
             getKeysList: () => [],
             getBalance: () => 10,
             getContractsMap: () => ({
@@ -30,10 +50,10 @@ describe("Send Get Account", () => {
         })
     });
 
-    await sendGetAccount(
+    const response = await sendGetAccount(
         await resolve(
             await build([
-                getAccount("0xABC123"),
+                getAccount("0x1654653399040a61"),
                 atBlockHeight(123)
             ])
         ),
@@ -58,15 +78,25 @@ describe("Send Get Account", () => {
 
     expect(unaryMockAddress).not.toBeUndefined()
     expect(unaryMockBlockHeight).not.toBeUndefined()
+
+    expect(response.account).toEqual(returnedAccount)
   })
 
-  test("GetAccountAtBlockHeightRequest", async () => {
+  test("GetAccountAtLatestBlockRequest", async () => {
     const unaryMock = jest.fn();
+
+    const returnedAccount = {
+        address: "0x1654653399040a61",
+        code: "contract",
+        keys: [],
+        balance: 10,
+        contracts: {}
+    }
 
     unaryMock.mockReturnValue({
         getAccount: () => ({
-            getAddress_asU8: () => jsonToUInt8Array({type: "Address", value: "0xABC123"}),
-            getCode_asU8: () => jsonToUInt8Array({type: "String", value: "contract"}),
+            getAddress_asU8: () => hexStrToUInt8Array("1654653399040a61"),
+            getCode_asU8: () => strToUInt8Array("contract"),
             getKeysList: () => [],
             getBalance: () => 10,
             getContractsMap: () => ({
@@ -75,10 +105,10 @@ describe("Send Get Account", () => {
         })
     });
 
-    await sendGetAccount(
+    const response = await sendGetAccount(
         await resolve(
             await build([
-                getAccount("0xABC123")
+                getAccount("0x1654653399040a61")
             ])
         ),
         {
@@ -100,6 +130,8 @@ describe("Send Get Account", () => {
     const unaryMockAddress = unaryMockRequest.getAddress()
 
     expect(unaryMockAddress).not.toBeUndefined()
+
+    expect(response.account).toEqual(returnedAccount)
   })
 
 })

--- a/packages/sdk/src/send/send-get-block-header.js
+++ b/packages/sdk/src/send/send-get-block-header.js
@@ -59,9 +59,12 @@ function constructResponse(ix, res) {
 export async function sendGetBlockHeader(ix, opts = {}) {
   ix = await ix
 
-  if (ix.block.id !== null) {
+  const interactionHasBlockID = ix.block.id !== null
+  const interactionHasBlockHeight = ix.block.height !== null
+
+  if (interactionHasBlockID) {
     return await sendGetBlockHeaderByIDRequest(ix, opts)
-  } else if (ix.block.height !== null) {
+  } else if (interactionHasBlockHeight) {
     return await sendGetBlockHeaderByHeightRequest(ix, opts)
   } else {
     return await sendGetLatestBlockHeaderRequest(ix, opts)

--- a/packages/sdk/src/send/send-get-block-header.js
+++ b/packages/sdk/src/send/send-get-block-header.js
@@ -8,10 +8,10 @@ const hexBuffer = hex => Buffer.from(hex, "hex")
 async function sendGetBlockHeaderByIDRequest(ix, opts) {
   const unary = opts.unary || defaultUnary
 
-  let req = new GetBlockHeaderByIDRequest()
+  const req = new GetBlockHeaderByIDRequest()
   req.setId(hexBuffer(ix.block.id))
 
-  let res = await unary(opts.node, AccessAPI.GetBlockHeaderByID, req)
+  const res = await unary(opts.node, AccessAPI.GetBlockHeaderByID, req)
 
   return constructResponse(ix, res)
 }
@@ -19,10 +19,10 @@ async function sendGetBlockHeaderByIDRequest(ix, opts) {
 async function sendGetBlockHeaderByHeightRequest(ix, opts) {
   const unary = opts.unary || defaultUnary
 
-  let req = new GetBlockHeaderByHeightRequest()
+  const req = new GetBlockHeaderByHeightRequest()
   req.setHeight(Number(ix.block.height))
 
-  let res = await unary(opts.node, AccessAPI.GetBlockHeaderByHeight, req)
+  const res = await unary(opts.node, AccessAPI.GetBlockHeaderByHeight, req)
 
   return constructResponse(ix, res)
 }
@@ -30,13 +30,13 @@ async function sendGetBlockHeaderByHeightRequest(ix, opts) {
 async function sendGetLatestBlockHeaderRequest(ix, opts) {
   const unary = opts.unary || defaultUnary
 
-  let req = new GetLatestBlockHeaderRequest()
+  const req = new GetLatestBlockHeaderRequest()
 
   if (ix.block?.isSealed) {
     req.setIsSealed(ix.block.isSealed)
   }
 
-  let res = await unary(opts.node, AccessAPI.GetLatestBlockHeader, req)
+  const res = await unary(opts.node, AccessAPI.GetLatestBlockHeader, req)
 
   return constructResponse(ix, res)
 }

--- a/packages/sdk/src/send/send-get-block-header.test.js
+++ b/packages/sdk/src/send/send-get-block-header.test.js
@@ -15,26 +15,47 @@ const jsonToUInt8Array = (json) => {
     return ret
 };
 
+const hexStrToUInt8Array = (hex) => {
+    return new Uint8Array(hex.match(/.{1,2}/g).map(byte => parseInt(byte, 16)));
+};
+
+const strToUInt8Array = (str) => {
+    var ret = new Uint8Array(str.length);
+    for (var i = 0; i < str.length; i++) {
+        ret[i] = str.charCodeAt(i);
+    }
+    return ret
+};
+
 describe("Send Get Block Header", () => {
   test("GetBlockHeaderByID", async () => {
     const unaryMock = jest.fn();
 
+    const dateNow = new Date(Date.now())
+
+    const returnedBlockHeader = {
+        id: "a1b2c3",
+        parentId: "a1b2c3",
+        height: 123,
+        timestamp: dateNow.toISOString(),
+    }
+
     unaryMock.mockReturnValue({
         getBlock: () => ({
-            getId_asU8: () => jsonToUInt8Array({type: "String", value: "123abc"}),
-            getParentId_asU8: () => jsonToUInt8Array({type: "String", value: "456def"}),
+            getId_asU8: () => hexStrToUInt8Array("a1b2c3"),
+            getParentId_asU8: () => hexStrToUInt8Array("a1b2c3"),
             getHeight: () => 123,
             getTimestamp: () => ({
-                toDate: () => new Date(Date.now())
+                toDate: () => dateNow
             })
         })
     });
 
-    await sendGetBlockHeader(
+    const response = await sendGetBlockHeader(
         await resolve(
             await build([
                 getBlockHeader(),
-                atBlockId("123abc")
+                atBlockId("a1b2c3")
             ])
         ),
         {
@@ -56,23 +77,34 @@ describe("Send Get Block Header", () => {
     const unaryMockId = unaryMockRequest.getId()
 
     expect(unaryMockId).not.toBeUndefined()
+
+    expect(response.blockHeader).toEqual(returnedBlockHeader)
   })
 
   test("GetBlockHeaderByHeight", async () => {
     const unaryMock = jest.fn();
 
+    const dateNow = new Date(Date.now())
+
+    const returnedBlockHeader = {
+        id: "a1b2c3",
+        parentId: "a1b2c3",
+        height: 123,
+        timestamp: dateNow.toISOString(),
+    }
+
     unaryMock.mockReturnValue({
         getBlock: () => ({
-            getId_asU8: () => jsonToUInt8Array({type: "String", value: "123abc"}),
-            getParentId_asU8: () => jsonToUInt8Array({type: "String", value: "456def"}),
+            getId_asU8: () => hexStrToUInt8Array("a1b2c3"),
+            getParentId_asU8: () => hexStrToUInt8Array("a1b2c3"),
             getHeight: () => 123,
             getTimestamp: () => ({
-                toDate: () => new Date(Date.now())
+                toDate: () => dateNow
             })
         })
     });
 
-    await sendGetBlockHeader(
+    const response = await sendGetBlockHeader(
         await resolve(
             await build([
                 getBlockHeader(),
@@ -98,23 +130,34 @@ describe("Send Get Block Header", () => {
     const unaryMockHeight = unaryMockRequest.getHeight()
 
     expect(unaryMockHeight).not.toBeUndefined()
+
+    expect(response.blockHeader).toEqual(returnedBlockHeader)
   })
 
   test("GetLatestBlockHeader - isSealed = false", async () => {
     const unaryMock = jest.fn();
 
+    const dateNow = new Date(Date.now())
+
+    const returnedBlockHeader = {
+        id: "a1b2c3",
+        parentId: "a1b2c3",
+        height: 123,
+        timestamp: dateNow.toISOString(),
+    }
+
     unaryMock.mockReturnValue({
         getBlock: () => ({
-            getId_asU8: () => jsonToUInt8Array({type: "String", value: "123abc"}),
-            getParentId_asU8: () => jsonToUInt8Array({type: "String", value: "456def"}),
+            getId_asU8: () => hexStrToUInt8Array("a1b2c3"),
+            getParentId_asU8: () => hexStrToUInt8Array("a1b2c3"),
             getHeight: () => 123,
             getTimestamp: () => ({
-                toDate: () => new Date(Date.now())
+                toDate: () => dateNow
             })
         })
     });
 
-    await sendGetBlockHeader(
+    const response = await sendGetBlockHeader(
         await resolve(
             await build([
                 getBlockHeader()
@@ -139,23 +182,34 @@ describe("Send Get Block Header", () => {
     const unaryMockIsSealed = unaryMockRequest.getIsSealed()
 
     expect(unaryMockIsSealed).toBe(false)
+
+    expect(response.blockHeader).toEqual(returnedBlockHeader)
   })
 
   test("GetLatestBlockHeader - isSealed = true", async () => {
     const unaryMock = jest.fn();
 
+    const dateNow = new Date(Date.now())
+
+    const returnedBlockHeader = {
+        id: "a1b2c3",
+        parentId: "a1b2c3",
+        height: 123,
+        timestamp: dateNow.toISOString(),
+    }
+
     unaryMock.mockReturnValue({
         getBlock: () => ({
-            getId_asU8: () => jsonToUInt8Array({type: "String", value: "123abc"}),
-            getParentId_asU8: () => jsonToUInt8Array({type: "String", value: "456def"}),
+            getId_asU8: () => hexStrToUInt8Array("a1b2c3"),
+            getParentId_asU8: () => hexStrToUInt8Array("a1b2c3"),
             getHeight: () => 123,
             getTimestamp: () => ({
-                toDate: () => new Date(Date.now())
+                toDate: () => dateNow
             })
         })
     });
 
-    await sendGetBlockHeader(
+    const response = await sendGetBlockHeader(
         await resolve(
             await build([
                 getBlockHeader(true)
@@ -180,6 +234,8 @@ describe("Send Get Block Header", () => {
     const unaryMockIsSealed = unaryMockRequest.getIsSealed()
 
     expect(unaryMockIsSealed).toBe(true)
+
+    expect(response.blockHeader).toEqual(returnedBlockHeader)
   })
 
 })

--- a/packages/sdk/src/send/send-get-block.js
+++ b/packages/sdk/src/send/send-get-block.js
@@ -8,10 +8,10 @@ const hexBuffer = hex => Buffer.from(hex, "hex")
 async function sendGetBlockByIDRequest(ix, opts) {
   const unary = opts.unary || defaultUnary
 
-  let req = new GetBlockByIDRequest()
+  const req = new GetBlockByIDRequest()
   req.setId(hexBuffer(ix.block.id))
 
-  let res = await unary(opts.node, AccessAPI.GetBlockByID, req)
+  const res = await unary(opts.node, AccessAPI.GetBlockByID, req)
 
   return constructResponse(ix, res)
 }
@@ -19,10 +19,10 @@ async function sendGetBlockByIDRequest(ix, opts) {
 async function sendGetBlockByHeightRequest(ix, opts) {
   const unary = opts.unary || defaultUnary
 
-  let req = new GetBlockByHeightRequest()
+  const req = new GetBlockByHeightRequest()
   req.setHeight(Number(ix.block.height))
     
-  let res = await unary(opts.node, AccessAPI.GetBlockByHeight, req)
+  const res = await unary(opts.node, AccessAPI.GetBlockByHeight, req)
 
   return constructResponse(ix, res)
 }
@@ -30,13 +30,13 @@ async function sendGetBlockByHeightRequest(ix, opts) {
 async function sendGetBlockRequest(ix, opts) {
   const unary = opts.unary || defaultUnary
 
-  let req = new GetLatestBlockRequest()
+  const req = new GetLatestBlockRequest()
 
   if (ix.block?.isSealed) {
     req.setIsSealed(ix.block.isSealed)
   }
 
-  let res = await unary(opts.node, AccessAPI.GetLatestBlock, req)
+  const res = await unary(opts.node, AccessAPI.GetLatestBlock, req)
 
   return constructResponse(ix, res)
 }

--- a/packages/sdk/src/send/send-get-block.js
+++ b/packages/sdk/src/send/send-get-block.js
@@ -74,9 +74,12 @@ function constructResponse(ix, res) {
 export async function sendGetBlock(ix, opts = {}) {
   ix = await ix
 
-  if (ix.block.id !== null) {
+  const interactionHasBlockID = ix.block.id !== null
+  const interactionHasBlockHeight = ix.block.height !== null
+
+  if (interactionHasBlockID) {
     return await sendGetBlockByIDRequest(ix, opts)
-  } else if (ix.block.height !== null) {
+  } else if (interactionHasBlockHeight) {
     return await sendGetBlockByHeightRequest(ix, opts)
   } else {
     return await sendGetBlockRequest(ix, opts)

--- a/packages/sdk/src/send/send-get-block.test.js
+++ b/packages/sdk/src/send/send-get-block.test.js
@@ -15,18 +15,42 @@ const jsonToUInt8Array = (json) => {
     return ret
 };
 
+const hexStrToUInt8Array = (hex) => {
+    return new Uint8Array(hex.match(/.{1,2}/g).map(byte => parseInt(byte, 16)));
+};
+
+const strToUInt8Array = (str) => {
+    var ret = new Uint8Array(str.length);
+    for (var i = 0; i < str.length; i++) {
+        ret[i] = str.charCodeAt(i);
+    }
+    return ret
+};
+
 describe("Send Get Block", () => {
   test("GetBlockByID", async () => {
     const unaryMock = jest.fn();
 
+    const dateNow = new Date(Date.now())
+
+    const returnedBlock = {
+        id: "a1b2c3",
+        parentId: "a1b2c3",
+        height: 123,
+        timestamp: dateNow.toISOString(),
+        collectionGuarantees: [],
+        blockSeals: [],
+        signatures: []
+    }
+
     unaryMock.mockReturnValue({
         getBlock: () => ({
-            getId_asU8: () => jsonToUInt8Array({type: "String", value: "123abc"}),
-            getParentId_asU8: () => jsonToUInt8Array({type: "String", value: "456def"}),
+            getId_asU8: () => hexStrToUInt8Array("a1b2c3"),
+            getParentId_asU8: () => hexStrToUInt8Array("a1b2c3"),
             getHeight: () => 123,
             getTimestamp: () => ({
                 toDate: () => ({
-                    toISOString: () => "05 October 2011 14:48 UTC"
+                    toISOString: () => dateNow.toISOString()
                 })
             }),
             getCollectionGuaranteesList: () => [],
@@ -35,11 +59,11 @@ describe("Send Get Block", () => {
         })
     });
 
-    await sendGetBlock(
+    const response = await sendGetBlock(
         await resolve(
             await build([
                 getBlock(),
-                atBlockId("123abc")
+                atBlockId("a1b2c3")
             ])
         ),
         {
@@ -61,19 +85,33 @@ describe("Send Get Block", () => {
     const unaryMockBlockId = unaryMockRequest.getId()
 
     expect(unaryMockBlockId).not.toBeUndefined()
+
+    expect(response.block).toEqual(returnedBlock)
   })
 
   test("GetBlockByHeight", async () => {
     const unaryMock = jest.fn();
 
+    const dateNow = new Date(Date.now())
+
+    const returnedBlock = {
+        id: "a1b2c3",
+        parentId: "a1b2c3",
+        height: 123,
+        timestamp: dateNow.toISOString(),
+        collectionGuarantees: [],
+        blockSeals: [],
+        signatures: []
+    }
+
     unaryMock.mockReturnValue({
         getBlock: () => ({
-            getId_asU8: () => jsonToUInt8Array({type: "String", value: "123abc"}),
-            getParentId_asU8: () => jsonToUInt8Array({type: "String", value: "456def"}),
+            getId_asU8: () => hexStrToUInt8Array("a1b2c3"),
+            getParentId_asU8: () => hexStrToUInt8Array("a1b2c3"),
             getHeight: () => 123,
             getTimestamp: () => ({
                 toDate: () => ({
-                    toISOString: () => "05 October 2011 14:48 UTC"
+                    toISOString: () => dateNow.toISOString()
                 })
             }),
             getCollectionGuaranteesList: () => [],
@@ -82,7 +120,7 @@ describe("Send Get Block", () => {
         })
     });
 
-    await sendGetBlock(
+    const response = await sendGetBlock(
         await resolve(
             await build([
                 getBlock(),
@@ -108,19 +146,33 @@ describe("Send Get Block", () => {
     const unaryMockBlockHeight = unaryMockRequest.getHeight()
 
     expect(unaryMockBlockHeight).not.toBeUndefined()
+
+    expect(response.block).toEqual(returnedBlock)
   })
 
   test("GetLatestBlock - isSealed = false", async () => {
     const unaryMock = jest.fn();
 
+    const dateNow = new Date(Date.now())
+
+    const returnedBlock = {
+        id: "a1b2c3",
+        parentId: "a1b2c3",
+        height: 123,
+        timestamp: dateNow.toISOString(),
+        collectionGuarantees: [],
+        blockSeals: [],
+        signatures: []
+    }
+
     unaryMock.mockReturnValue({
         getBlock: () => ({
-            getId_asU8: () => jsonToUInt8Array({type: "String", value: "123abc"}),
-            getParentId_asU8: () => jsonToUInt8Array({type: "String", value: "456def"}),
+            getId_asU8: () => hexStrToUInt8Array("a1b2c3"),
+            getParentId_asU8: () => hexStrToUInt8Array("a1b2c3"),
             getHeight: () => 123,
             getTimestamp: () => ({
                 toDate: () => ({
-                    toISOString: () => "05 October 2011 14:48 UTC"
+                    toISOString: () => dateNow.toISOString()
                 })
             }),
             getCollectionGuaranteesList: () => [],
@@ -129,7 +181,7 @@ describe("Send Get Block", () => {
         })
     });
 
-    await sendGetBlock(
+    const response = await sendGetBlock(
         await resolve(
             await build([
                 getBlock()
@@ -154,19 +206,33 @@ describe("Send Get Block", () => {
     const unaryMockIsSealed = unaryMockRequest.getIsSealed()
 
     expect(unaryMockIsSealed).toBe(false)
+
+    expect(response.block).toEqual(returnedBlock)
   })
 
   test("GetLatestBlock - isSealed = true", async () => {
     const unaryMock = jest.fn();
 
+    const dateNow = new Date(Date.now())
+
+    const returnedBlock = {
+        id: "a1b2c3",
+        parentId: "a1b2c3",
+        height: 123,
+        timestamp: dateNow.toISOString(),
+        collectionGuarantees: [],
+        blockSeals: [],
+        signatures: []
+    }
+
     unaryMock.mockReturnValue({
         getBlock: () => ({
-            getId_asU8: () => jsonToUInt8Array({type: "String", value: "123abc"}),
-            getParentId_asU8: () => jsonToUInt8Array({type: "String", value: "456def"}),
+            getId_asU8: () => hexStrToUInt8Array("a1b2c3"),
+            getParentId_asU8: () => hexStrToUInt8Array("a1b2c3"),
             getHeight: () => 123,
             getTimestamp: () => ({
                 toDate: () => ({
-                    toISOString: () => "05 October 2011 14:48 UTC"
+                    toISOString: () => dateNow.toISOString()
                 })
             }),
             getCollectionGuaranteesList: () => [],
@@ -175,7 +241,7 @@ describe("Send Get Block", () => {
         })
     });
 
-    await sendGetBlock(
+    const response = await sendGetBlock(
         await resolve(
             await build([
                 getBlock(true)
@@ -200,6 +266,8 @@ describe("Send Get Block", () => {
     const unaryMockIsSealed = unaryMockRequest.getIsSealed()
 
     expect(unaryMockIsSealed).toBe(true)
+
+    expect(response.block).toEqual(returnedBlock)
   })
 
 })

--- a/packages/sdk/src/send/send-get-collection.js
+++ b/packages/sdk/src/send/send-get-collection.js
@@ -10,10 +10,10 @@ export async function sendGetCollection(ix, opts = {}) {
 
   ix = await ix
 
-  let req = new GetCollectionByIDRequest()
+  const req = new GetCollectionByIDRequest()
   req.setId(hexBuffer(ix.collection.id))
 
-  let res = await unary(opts.node, AccessAPI.GetCollectionByID, req)
+  const res = await unary(opts.node, AccessAPI.GetCollectionByID, req)
 
   const collection = res.getCollection()
 

--- a/packages/sdk/src/send/send-get-collection.test.js
+++ b/packages/sdk/src/send/send-get-collection.test.js
@@ -13,23 +13,41 @@ const jsonToUInt8Array = (json) => {
     return ret
 };
 
+const hexStrToUInt8Array = (hex) => {
+    return new Uint8Array(hex.match(/.{1,2}/g).map(byte => parseInt(byte, 16)));
+};
+
+const strToUInt8Array = (str) => {
+    var ret = new Uint8Array(str.length);
+    for (var i = 0; i < str.length; i++) {
+        ret[i] = str.charCodeAt(i);
+    }
+    return ret
+};
+
+
 describe("Send Get Collection", () => {
   test("GetCollection", async () => {
     const unaryMock = jest.fn();
 
+    const returnedCollection = {
+        id: "a1b2c3",
+        transactionIds: ["a1b2c3"]
+    }
+
     unaryMock.mockReturnValue({
         getCollection: () => ({
-            getId_asU8: () => jsonToUInt8Array({type: "String", value: "123abc"}),
+            getId_asU8: () => hexStrToUInt8Array("a1b2c3"),
             getTransactionIdsList: () => ([
-                jsonToUInt8Array({type: "String", value: "456def"})
+                hexStrToUInt8Array("a1b2c3")
             ]),
         })
     });
 
-    await sendGetCollection(
+    const response = await sendGetCollection(
         await resolve(
             await build([
-                getCollection("123abc"),
+                getCollection("a1b2c3"),
             ])
         ),
         {
@@ -51,6 +69,9 @@ describe("Send Get Collection", () => {
     const unaryMockCollectionId = unaryMockRequest.getId()
 
     expect(unaryMockCollectionId).not.toBeUndefined()
+
+    expect(response.collection.id).toBe(returnedCollection.id)
+    expect(response.collection.transactionIds[0]).toBe(returnedCollection.transactionIds[0])
   })
 
 })

--- a/packages/sdk/src/send/send-get-events.js
+++ b/packages/sdk/src/send/send-get-events.js
@@ -67,13 +67,17 @@ export async function sendGetEvents(ix, opts = {}) {
   ix = await ix
 
   invariant(
-    ix.events.start !== null || ix.events.blockIds.length > 0,
-    "SendGetEventsError: Unable to determine which get events request to send."
+    ix.events.start !== null || (
+      ix.events.blockIds !== null &&
+      Array.isArray(ix.events.blockIds) &&
+      ix.events.blockIds.length > 0
+    ),
+    "SendGetEventsError: Unable to determine which get events request to send. Either a block height range, or block IDs must be specified."
   )
   
   if (ix.events.start !== null) {
     return await sendGetEventsForHeightRangeRequest(ix, opts)
-  } else if (ix.events.blockIds.length > 0) {
+  } else {
     return await sendGetEventsForBlockIDsRequest(ix, opts)
   }
 }

--- a/packages/sdk/src/send/send-get-events.js
+++ b/packages/sdk/src/send/send-get-events.js
@@ -15,8 +15,6 @@ async function sendGetEventsForHeightRangeRequest(ix, opts) {
   req.setStartHeight(Number(ix.events.start))
   req.setEndHeight(Number(ix.events.end))
 
-  res = await unary(opts.node, AccessAPI.GetEventsForHeightRange, req)
-
   let res = await unary(opts.node, AccessAPI.GetEventsForHeightRange, req)
 
   return constructResponse(ix, res)

--- a/packages/sdk/src/send/send-get-events.js
+++ b/packages/sdk/src/send/send-get-events.js
@@ -1,32 +1,43 @@
 import {GetEventsForHeightRangeRequest, GetEventsForBlockIDsRequest, AccessAPI} from "@onflow/protobuf"
+import {invariant} from "@onflow/util-invariant"
 import {response} from "../response/response.js"
 import {unary as defaultUnary} from "./unary"
 
 const u8ToHex = u8 => Buffer.from(u8).toString("hex")
 const hexBuffer = hex => Buffer.from(hex, "hex")
 
-export async function sendGetEvents(ix, opts = {}) {
+async function sendGetEventsForHeightRangeRequest(ix, opts) {
   const unary = opts.unary || defaultUnary
-  
-  ix = await ix
- 
-  let res
-  const req = ix.events.start ? new GetEventsForHeightRangeRequest() : new GetEventsForBlockIDsRequest()
+
+  let req = new GetEventsForHeightRangeRequest()
   req.setType(ix.events.eventType)
-  
-  if (ix.events.start) {
-    req.setStartHeight(Number(ix.events.start))
-    req.setEndHeight(Number(ix.events.end))
 
-    res = await unary(opts.node, AccessAPI.GetEventsForHeightRange, req)
-  } else {
-    ix.events.blockIds.forEach(id =>
-      req.addBlockIds(hexBuffer(id))
-    )
+  req.setStartHeight(Number(ix.events.start))
+  req.setEndHeight(Number(ix.events.end))
 
-    res = await unary(opts.node, AccessAPI.GetEventsForBlockIDs, req)
-  }
+  res = await unary(opts.node, AccessAPI.GetEventsForHeightRange, req)
 
+  let res = await unary(opts.node, AccessAPI.GetEventsForHeightRange, req)
+
+  return constructResponse(ix, res)
+}
+
+async function sendGetEventsForBlockIDsRequest(ix, opts) {
+  const unary = opts.unary || defaultUnary
+
+  const req = new GetEventsForBlockIDsRequest()
+  req.setType(ix.events.eventType)
+
+  ix.events.blockIds.forEach(id =>
+    req.addBlockIds(hexBuffer(id))
+  )
+
+  let res = await unary(opts.node, AccessAPI.GetEventsForBlockIDs, req)
+
+  return constructResponse(ix, res)
+}
+
+function constructResponse(ix, res) {
   let ret = response()
   ret.tag = ix.tag
 
@@ -52,4 +63,19 @@ export async function sendGetEvents(ix, opts = {}) {
   }, [])
 
   return ret
+}
+
+export async function sendGetEvents(ix, opts = {}) {  
+  ix = await ix
+
+  invariant(
+    ix.events.start !== null || ix.events.blockIds.length > 0,
+    "SendGetEventsError: Unable to determine which get events request to send."
+  )
+  
+  if (ix.events.start !== null) {
+    return await sendGetEventsForHeightRangeRequest(ix, opts)
+  } else if (ix.events.blockIds.length > 0) {
+    return await sendGetEventsForBlockIDsRequest(ix, opts)
+  }
 }

--- a/packages/sdk/src/send/send-get-events.js
+++ b/packages/sdk/src/send/send-get-events.js
@@ -9,13 +9,13 @@ const hexBuffer = hex => Buffer.from(hex, "hex")
 async function sendGetEventsForHeightRangeRequest(ix, opts) {
   const unary = opts.unary || defaultUnary
 
-  let req = new GetEventsForHeightRangeRequest()
+  const req = new GetEventsForHeightRangeRequest()
   req.setType(ix.events.eventType)
 
   req.setStartHeight(Number(ix.events.start))
   req.setEndHeight(Number(ix.events.end))
 
-  let res = await unary(opts.node, AccessAPI.GetEventsForHeightRange, req)
+  const res = await unary(opts.node, AccessAPI.GetEventsForHeightRange, req)
 
   return constructResponse(ix, res)
 }
@@ -30,7 +30,7 @@ async function sendGetEventsForBlockIDsRequest(ix, opts) {
     req.addBlockIds(hexBuffer(id))
   )
 
-  let res = await unary(opts.node, AccessAPI.GetEventsForBlockIDs, req)
+  const res = await unary(opts.node, AccessAPI.GetEventsForBlockIDs, req)
 
   return constructResponse(ix, res)
 }
@@ -66,16 +66,15 @@ function constructResponse(ix, res) {
 export async function sendGetEvents(ix, opts = {}) {  
   ix = await ix
 
+  const interactionContainsBlockHeightRange = ix.events.start !== null 
+  const interactionContainsBlockIDsList = Array.isArray(ix.events.blockIds) && ix.events.blockIds.length > 0
+ 
   invariant(
-    ix.events.start !== null || (
-      ix.events.blockIds !== null &&
-      Array.isArray(ix.events.blockIds) &&
-      ix.events.blockIds.length > 0
-    ),
+    interactionContainsBlockHeightRange || interactionContainsBlockIDsList,
     "SendGetEventsError: Unable to determine which get events request to send. Either a block height range, or block IDs must be specified."
   )
   
-  if (ix.events.start !== null) {
+  if (interactionContainsBlockHeightRange) {
     return await sendGetEventsForHeightRangeRequest(ix, opts)
   } else {
     return await sendGetEventsForBlockIDsRequest(ix, opts)

--- a/packages/sdk/src/send/send-get-events.test.js
+++ b/packages/sdk/src/send/send-get-events.test.js
@@ -15,24 +15,51 @@ const jsonToUInt8Array = (json) => {
     return ret
 };
 
+const hexStrToUInt8Array = (hex) => {
+    return new Uint8Array(hex.match(/.{1,2}/g).map(byte => parseInt(byte, 16)));
+};
+
+const strToUInt8Array = (str) => {
+    var ret = new Uint8Array(str.length);
+    for (var i = 0; i < str.length; i++) {
+        ret[i] = str.charCodeAt(i);
+    }
+    return ret
+};
+
 describe("Send Get Events", () => {
   test("GetEventsForBlockIDs", async () => {
     const unaryMock = jest.fn();
 
+    const dateNow = new Date(Date.now())
+
+    const returnedEvents = [
+        {
+            blockId: "a1b2c3",
+            blockHeight: 123,
+            blockTimestamp: dateNow.toISOString(),
+            type: "MyEvent",
+            transactionId: "a1b2c3",
+            transactionIndex: 123,
+            eventIndex: 456,
+            payload: {type: "String", value: "Hello, Flow"}
+        }
+    ]   
+
     unaryMock.mockReturnValue({
         getResultsList: () => [
             {
-                getBlockId_asU8: () => jsonToUInt8Array({type: "String", value: "123abc"}),
+                getBlockId_asU8: () => hexStrToUInt8Array("a1b2c3"),
                 getBlockHeight: () => 123,
                 getBlockTimestamp: () => ({
                     toDate: () => ({
-                        toISOString: () => "05 October 2011 14:48 UTC"
+                        toISOString: () => dateNow.toISOString(),
                     })
                 }),
                 getEventsList: () => ([
                     {
                         getType: () => "MyEvent",
-                        getTransactionId_asU8: () => jsonToUInt8Array({type: "String", value: "TxId"}),
+                        getTransactionId_asU8: () => hexStrToUInt8Array("a1b2c3"),
                         getTransactionIndex: () => 123,
                         getEventIndex: () => 456,
                         getPayload_asU8: () => jsonToUInt8Array({type: "String", value: "Hello, Flow"}),
@@ -42,10 +69,10 @@ describe("Send Get Events", () => {
         ]
     });
 
-    await sendGetEvents(
+    const response = await sendGetEvents(
         await resolve(
             await build([
-                getEventsAtBlockIds("MyEvent", ["abc123"]),
+                getEventsAtBlockIds("MyEvent", ["a1b2c3"]),
             ])
         ),
         {
@@ -70,25 +97,42 @@ describe("Send Get Events", () => {
     expect(unaryMockType).not.toBeUndefined()
     expect(unaryMockBlockIds).not.toBeUndefined()
     expect(unaryMockBlockIds.length).toBe(1)
+
+    expect(response.events[0]).toStrictEqual(returnedEvents[0])
   })
 
   test("GetEventsForHeightRange", async () => {
     const unaryMock = jest.fn();
 
+    const dateNow = new Date(Date.now())
+
+    const returnedEvents = [
+        {
+            blockId: "a1b2c3",
+            blockHeight: 123,
+            blockTimestamp: dateNow.toISOString(),
+            type: "MyEvent",
+            transactionId: "a1b2c3",
+            transactionIndex: 123,
+            eventIndex: 456,
+            payload: {type: "String", value: "Hello, Flow"}
+        }
+    ]   
+
     unaryMock.mockReturnValue({
         getResultsList: () => [
             {
-                getBlockId_asU8: () => jsonToUInt8Array({type: "String", value: "123abc"}),
+                getBlockId_asU8: () => hexStrToUInt8Array("a1b2c3"),
                 getBlockHeight: () => 123,
                 getBlockTimestamp: () => ({
                     toDate: () => ({
-                        toISOString: () => "05 October 2011 14:48 UTC"
+                        toISOString: () => dateNow.toISOString(),
                     })
                 }),
                 getEventsList: () => ([
                     {
                         getType: () => "MyEvent",
-                        getTransactionId_asU8: () => jsonToUInt8Array({type: "String", value: "TxId"}),
+                        getTransactionId_asU8: () => hexStrToUInt8Array("a1b2c3"),
                         getTransactionIndex: () => 123,
                         getEventIndex: () => 456,
                         getPayload_asU8: () => jsonToUInt8Array({type: "String", value: "Hello, Flow"}),
@@ -98,7 +142,7 @@ describe("Send Get Events", () => {
         ]
     });
 
-    await sendGetEvents(
+    const response = await sendGetEvents(
         await resolve(
             await build([
                 getEventsAtBlockHeightRange("MyEvent", 123, 456),
@@ -127,6 +171,8 @@ describe("Send Get Events", () => {
     expect(unaryMockType).not.toBeUndefined()
     expect(unaryMockStartHeight).not.toBeUndefined()
     expect(unaryMockEndHeight).not.toBeUndefined()
+
+    expect(response.events[0]).toStrictEqual(returnedEvents[0])
   })
 
 })

--- a/packages/sdk/src/send/send-get-transaction.test.js
+++ b/packages/sdk/src/send/send-get-transaction.test.js
@@ -13,29 +13,58 @@ const jsonToUInt8Array = (json) => {
     return ret
 };
 
+const hexStrToUInt8Array = (hex) => {
+    return new Uint8Array(hex.match(/.{1,2}/g).map(byte => parseInt(byte, 16)));
+};
+
+const strToUInt8Array = (str) => {
+    var ret = new Uint8Array(str.length);
+    for (var i = 0; i < str.length; i++) {
+        ret[i] = str.charCodeAt(i);
+    }
+    return ret
+};
+
+
 describe("Get Transaction", () => {
   test("GetTransactionResult", async () => {
     const unaryMock = jest.fn();
 
+    const returnedTransaction = {
+        script: "Cadence Code",
+        args: [],
+        referenceBlockId: "a1b2c3",
+        gasLimit: 123,
+        proposalKey: {
+            address: "1654653399040a61",
+            keyId: 1,
+            sequenceNumber: 1
+        },
+        payer: "1654653399040a61",
+        authorizers: [],
+        payloadSignatures: [],
+        envelopeSignatures: []
+    }
+
     unaryMock.mockReturnValue({
         getTransaction: () => ({
-            getScript_asU8: () => jsonToUInt8Array({type: "String", value: "Cadence Code"}),
+            getScript_asU8: () => strToUInt8Array("Cadence Code"),
             getArgumentsList: () => ([]),
-            getReferenceBlockId_asU8: () => jsonToUInt8Array({type: "String", value: "abc123"}),
+            getReferenceBlockId_asU8: () => hexStrToUInt8Array("a1b2c3"),
             getGasLimit: () => 123,
             getProposalKey: () => ({
-                getAddress_asU8: () => jsonToUInt8Array({type: "Address", value: "0xABC123"}),
+                getAddress_asU8: () => hexStrToUInt8Array("1654653399040a61"),
                 getKeyId: () => 1,
                 getSequenceNumber: () => 1,
             }),
-            getPayer_asU8: () => jsonToUInt8Array({type: "Address", value: "0xABC123"}),
+            getPayer_asU8: () => hexStrToUInt8Array("1654653399040a61"),
             getAuthorizersList: () => ([]),
             getPayloadSignaturesList: () => ([]),
             getEnvelopeSignaturesList: () => ([])
         })
     });
 
-    await sendGetTransaction(
+    const response = await sendGetTransaction(
         await resolve(
             await build([
                 getTransaction("MyTxID"),
@@ -60,6 +89,8 @@ describe("Get Transaction", () => {
     const unaryMockId = unaryMockRequest.getId()
 
     expect(unaryMockId).not.toBeUndefined()
+
+    expect(response.transaction).toStrictEqual(returnedTransaction)
   })
 
 })

--- a/packages/sdk/src/send/send-transaction.test.js
+++ b/packages/sdk/src/send/send-transaction.test.js
@@ -18,15 +18,29 @@ const jsonToUInt8Array = (json) => {
     return ret
 };
 
+const hexStrToUInt8Array = (hex) => {
+    return new Uint8Array(hex.match(/.{1,2}/g).map(byte => parseInt(byte, 16)));
+};
+
+const strToUInt8Array = (str) => {
+    var ret = new Uint8Array(str.length);
+    for (var i = 0; i < str.length; i++) {
+        ret[i] = str.charCodeAt(i);
+    }
+    return ret
+};
+
 describe("Transaction", () => {
   test("SendTransaction", async () => {
     const unaryMock = jest.fn();
 
+    const returnedTransactionId = "a1b2c3"
+
     unaryMock.mockReturnValue({
-        getId_asU8: () => jsonToUInt8Array({type: "String", value: "abc123"})
+        getId_asU8: () => hexStrToUInt8Array("a1b2c3")
     });
 
-    await sendTransaction(
+    const response = await sendTransaction(
         await resolve(
             await build([
                 transaction`cadence transaction`,
@@ -89,6 +103,8 @@ describe("Transaction", () => {
     const unaryMockRequest = unaryMock.mock.calls[0][2]
 
     expect(unaryMockRequest).not.toBeUndefined()
+
+    expect(response.transactionId).toBe(returnedTransactionId)
   })
 
 })


### PR DESCRIPTION
[sdk] -- Refactors Send Functions to prevent and mitigate cases where the expected request type cannot be determined.

@psiemens : This PR addresses the concerns raised in https://github.com/onflow/flow-js-sdk/pull/714 , as well as propagates the new pattern of splitting up the various individual send functions for each AccessAPI method out of each exported send function.