### PR TITLE
[sdk] Update how payload sigs are returned from createSignableVoucher

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - YYYY-MM-DD **BREAKING?** -- Who: description
 
+- 2021-07-14 -- Update `createSignableVoucher` to return `payloadSigs` and `envelopeSigs`. Addresses CORS bug.
+
 ## 0.0.51-alpha.1 -- 2021-07-13
 
 - 2021-07-13 -- [@orodio](https://github.com/orodio): Top level now exposes `TestUtils`

--- a/packages/sdk/src/resolve/__snapshots__/resolve-signatures.test.js.snap
+++ b/packages/sdk/src/resolve/__snapshots__/resolve-signatures.test.js.snap
@@ -42,14 +42,15 @@ Object {
                 ],
                 "cadence": "",
                 "computeLimit": 156,
-                "payer": "0xfoo",
-                "payloadSigs": Array [
+                "envelopeSigs": Array [
                   Object {
                     "address": "0xfoo",
                     "keyId": 1,
                     "sig": null,
                   },
                 ],
+                "payer": "0xfoo",
+                "payloadSigs": Array [],
                 "proposalKey": Object {
                   "address": "0xfoo",
                   "keyId": 1,

--- a/packages/sdk/src/resolve/resolve-accounts.test.js
+++ b/packages/sdk/src/resolve/resolve-accounts.test.js
@@ -40,7 +40,12 @@ test("Voucher in PreSignable", async () => {
       limit(156),
       proposer(authz),
       authorizations([authz]),
-      payer(authz),
+      payer({
+        addr: "0x02",
+        signingFunction: () => ({signature: "123"}),
+        keyId: 0,
+        sequenceNum: 123,
+      }),
       ref("123"),
     ])
   )
@@ -53,12 +58,12 @@ test("Voucher in PreSignable", async () => {
     computeLimit: 156,
     arguments: [],
     proposalKey: {address: "0x01", keyId: 1, sequenceNum: 123},
-    payer: "0x01",
+    payer: "0x02",
     authorizers: ["0x01"],
     payloadSigs: [
       {address: "0x01", keyId: 1, sig: "123"},
       {address: "0x01", keyId: 1, sig: "123"},
-      {address: "0x01", keyId: 1, sig: "123"},
     ],
+    envelopeSigs: [{address: "0x02", keyId: 0, sig: "123"}],
   })
 })

--- a/packages/sdk/src/resolve/resolve-signatures.js
+++ b/packages/sdk/src/resolve/resolve-signatures.js
@@ -59,6 +59,20 @@ function fetchSignature(ix, payload) {
 }
 
 export const createSignableVoucher = ix => {
+  const buildInsideSigners = () =>
+    findInsideSigners(ix).map(id => ({
+      address: withPrefix(ix.accounts[id].addr),
+      keyId: ix.accounts[id].keyId,
+      sig: ix.accounts[id].signature,
+    }))
+
+  const buildOutsideSigners = () =>
+    findOutsideSigners(ix).map(id => ({
+      address: withPrefix(ix.accounts[id].addr),
+      keyId: ix.accounts[id].keyId,
+      sig: ix.accounts[id].signature,
+    }))
+
   return {
     cadence: ix.message.cadence,
     refBlock: ix.message.refBlock || null,
@@ -75,18 +89,8 @@ export const createSignableVoucher = ix => {
       .reduce((prev, current) => {
         return prev.find(item => item === current) ? prev : [...prev, current]
       }, []),
-    payloadSigs: [
-      ...findInsideSigners(ix).map(id => ({
-        address: withPrefix(ix.accounts[id].addr),
-        keyId: ix.accounts[id].keyId,
-        sig: ix.accounts[id].signature,
-      })),
-      ...findOutsideSigners(ix).map(id => ({
-        address: withPrefix(ix.accounts[id].addr),
-        keyId: ix.accounts[id].keyId,
-        sig: ix.accounts[id].signature,
-      })),
-    ],
+    payloadSigs: buildInsideSigners(),
+    envelopeSigs: buildOutsideSigners(),
   }
 }
 

--- a/packages/sdk/src/resolve/resolve-signatures.test.js
+++ b/packages/sdk/src/resolve/resolve-signatures.test.js
@@ -87,8 +87,8 @@ test("voucher in signable", async () => {
     payloadSigs: [
       {address: "0x01", keyId: 0, sig: "123"},
       {address: "0x01", keyId: 0, sig: "123"},
-      {address: "0x02", keyId: 0, sig: "123"},
     ],
+    envelopeSigs: [{address: "0x02", keyId: 0, sig: "123"}],
   })
 })
 


### PR DESCRIPTION
### Description
Update how payload sigs are returned in `createSignableVoucher`

- Build and return `payloadSigs` and `envelopeSigs` separately
- Fixes CORS bug