### PR TITLE
[fcl] Quickfix for verifyUserSignatures

### DIFF
--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 
+- 2021-07-21 -- Updates `verifyUserSignatures` to use `account` util from `@onflow/sdk`
+
 ## 0.0.74 - 2021-07-20
 
 - 2021-07-20 -- SDK VSN 0.0.51

--- a/packages/fcl/src/current-user/index.js
+++ b/packages/fcl/src/current-user/index.js
@@ -325,7 +325,7 @@ async function verifyUserSignatures(msg, compSigs) {
       invariant(typeof cs.signature === "string", "signature must be a string")
 
       try {
-        const account = await fcl.account(cs.addr)
+        const account = await account(cs.addr)
         weights.push(account.keys[cs.keyId].weight.toFixed(1))
         signAlgos.push(account.keys[cs.keyId].signAlgo)
         signatures.push(cs.signature)


### PR DESCRIPTION
### Quickfix for verifyUserSignatures

- Updates `verifyUserSignatures` to use `account` util from `@onflow/sdk`