### PR TITLE
[fcl] Update to revert default authn/authz method/view

### DIFF
--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 
+- 2021-07-23 -- Reverts to iFrame as default wallet method/view.
+
 ## 0.0.77-pain.1
 
 > **PAIN** builds are experimental builds that change a fundamental feature in a not yet backwards compatible way.

--- a/packages/fcl/src/current-user/exec-service/index.js
+++ b/packages/fcl/src/current-user/exec-service/index.js
@@ -5,7 +5,7 @@ import {execPopRPC} from "./strategies/pop-rpc"
 const STRATEGIES = {
   "HTTP/RPC": execHttpPost,
   "HTTP/POST": execHttpPost,
-  "IFRAME/RPC": execPopRPC,
+  "IFRAME/RPC": execIframeRPC,
   "POP/RPC": execPopRPC,
 }
 

--- a/packages/fcl/src/current-user/exec-service/strategies/iframe-rpc.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/iframe-rpc.js
@@ -33,7 +33,7 @@ export function execIframeRPC(service, body, opts) {
         }
       },
 
-      onResponse(e, {send, close}) {
+      onResponse(e, {close}) {
         try {
           if (typeof e.data !== "object") return
           const resp = normalizePollingResponse(e.data)

--- a/packages/fcl/src/current-user/exec-service/strategies/pop-rpc.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/pop-rpc.js
@@ -33,7 +33,7 @@ export function execPopRPC(service, body, opts) {
         }
       },
 
-      onResponse(e, {send, close}) {
+      onResponse(e, {close}) {
         try {
           if (typeof e.data !== "object") return
           const resp = normalizePollingResponse(e.data)

--- a/packages/fcl/src/fcl.js
+++ b/packages/fcl/src/fcl.js
@@ -9,14 +9,14 @@ export {events} from "./events"
 import {currentUser} from "./current-user"
 export {currentUser}
 
-export const authenticate = opts => currentUser().authenticate(opts)
+export const authenticate = () => currentUser().authenticate()
 export const unauthenticate = () => currentUser().unauthenticate()
-export const reauthenticate = opts => {
+export const reauthenticate = () => {
   currentUser().unauthenticate()
-  return currentUser().authenticate(opts)
+  return currentUser().authenticate()
 }
-export const signUp = opts => currentUser().authenticate()
-export const logIn = opts => currentUser().authenticate()
+export const signUp = () => currentUser().authenticate()
+export const logIn = () => currentUser().authenticate()
 
 export const authz = currentUser().authorization
 


### PR DESCRIPTION
### Reverts to iFrame as default wallet method/view

- Adds use of `discovery.wallet.view` to configure `authn` view