### PR TITLE
[fcl] Update currentUser.authenticate and execService

### DIFF
--- a/packages/fcl/CHANGELOG.md
+++ b/packages/fcl/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 - YYYY-MM-DD **BREAKING?** -- description
 
+- 2021-07-26 -- Updates `currentUser.authenticate()` to use execService with parameter destructuring.
+
 ## 0.0.77-alpha.1 - 2021-07-23
 
-- 2021-07-23 -- VSN `@onflow/sdk` 0.0.53 -> 0.0.54 
+- 2021-07-23 -- VSN `@onflow/sdk` 0.0.53 -> 0.0.54
 - 2021-07-23 -- Reverts to iFrame as default wallet method/view.
 
 ## 0.0.77-pain.1

--- a/packages/fcl/src/current-user/exec-service/index.js
+++ b/packages/fcl/src/current-user/exec-service/index.js
@@ -9,11 +9,11 @@ const STRATEGIES = {
   "POP/RPC": execPopRPC,
 }
 
-export async function execService(service, msg, opts = {}) {
+export async function execService({service, msg = {}, opts = {}}) {
   try {
     return STRATEGIES[service.method](service, msg, opts)
   } catch (error) {
-    console.error("execService(service, msg)", error, {service, msg, opts})
+    console.error("execService({service, msg = {}, opts = {}})", error, {service, msg, opts})
     throw error
   }
 }

--- a/packages/fcl/src/current-user/exec-service/strategies/iframe-rpc.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/iframe-rpc.js
@@ -1,6 +1,7 @@
 import {uid} from "@onflow/util-uid"
 import {frame} from "./utils/frame"
 import {normalizePollingResponse} from "../../normalize/polling-response"
+import {configLens} from "../../../default-config"
 
 export function execIframeRPC(service, body, opts) {
   return new Promise((resolve, reject) => {
@@ -10,7 +11,7 @@ export function execIframeRPC(service, body, opts) {
     body.data = service.data
 
     frame(service, {
-      onReady(_, {send}) {
+      async onReady(_, {send}) {
         try {
           send({
             type: "FCL:FRAME:READY:RESPONSE",
@@ -18,6 +19,10 @@ export function execIframeRPC(service, body, opts) {
             service: {
               params: service.params,
               data: service.data,
+            },
+            config: {
+              services: await configLens(/^service\./),
+              app: await configLens(/^app\.detail\./),
             },
           })
           if (includeOlderJsonRpcCall) {

--- a/packages/fcl/src/current-user/exec-service/strategies/pop-rpc.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/pop-rpc.js
@@ -1,6 +1,7 @@
 import {uid} from "@onflow/util-uid"
 import {pop} from "./utils/pop"
 import {normalizePollingResponse} from "../../normalize/polling-response"
+import {configLens} from "../../../default-config"
 
 export function execPopRPC(service, body, opts) {
   return new Promise((resolve, reject) => {
@@ -10,7 +11,7 @@ export function execPopRPC(service, body, opts) {
     body.data = service.data
 
     pop(service, {
-      onReady(_, {send}) {
+      async onReady(_, {send}) {
         try {
           send({
             type: "FCL:FRAME:READY:RESPONSE",
@@ -18,6 +19,10 @@ export function execPopRPC(service, body, opts) {
             service: {
               params: service.params,
               data: service.data,
+            },
+            config: {
+              services: await configLens(/^service\./),
+              app: await configLens(/^app\.detail\./),
             },
           })
           if (includeOlderJsonRpcCall) {

--- a/packages/fcl/src/current-user/exec-service/strategies/utils/pop.js
+++ b/packages/fcl/src/current-user/exec-service/strategies/utils/pop.js
@@ -45,7 +45,7 @@ export function pop(service, opts = {}) {
       if (e.data.type === "FCL::CHALLENGE::CANCEL") close()
       if (e.data.type === "FCL::CANCEL") close()
     } catch (error) {
-      console.error("Frame Callback Error", error)
+      console.error("Popup Callback Error", error)
       close()
     }
   }
@@ -57,7 +57,7 @@ export function pop(service, opts = {}) {
       unmount()
       onClose()
     } catch (error) {
-      console.error("Frame Close Error", error)
+      console.error("Popup Close Error", error)
     }
   }
 
@@ -65,7 +65,7 @@ export function pop(service, opts = {}) {
     try {
       $pop.postMessage(JSON.parse(JSON.stringify(msg || {})), "*")
     } catch (error) {
-      console.error("Frame Send Error", msg, error)
+      console.error("Popup Send Error", msg, error)
     }
   }
 }

--- a/packages/fcl/src/current-user/normalize/polling-response.js
+++ b/packages/fcl/src/current-user/normalize/polling-response.js
@@ -13,6 +13,9 @@ import {normalizeFrame} from "./frame"
 // }
 export function normalizePollingResponse(resp) {
   if (resp == null) return null
+  if (!!resp.addr || !!resp.services) {
+    resp = {status: "APPROVED", data: {...resp}}
+  }
 
   switch (resp["f_vsn"]) {
     case "1.0.0":
@@ -22,7 +25,7 @@ export function normalizePollingResponse(resp) {
       return {
         ...POLLING_RESPONSE_PRAGMA,
         status: resp.status,
-        reason: resp.reason,
+        reason: resp.reason ?? null,
         data: resp.compositeSignature || resp.data || {},
         updates: normalizeBackChannelRpc(resp.authorizationUpdates),
         local: normalizeFrame((resp.local || [])[0]),

--- a/packages/fcl/src/default-config.js
+++ b/packages/fcl/src/default-config.js
@@ -3,3 +3,14 @@ import {config} from "@onflow/sdk"
 config()
   .put("accessNode.api", "http://localhost:8080")
   .put("challenge.handshake", "http://localhost:8700/authenticate")
+  .put("discovery.wallet", "http://localhost:8701/fcl/authn")
+  .put("discovery.wallet.method", "frame")
+
+export async function configLens(regex) {
+  return Object.fromEntries(
+    Object.entries(await config().where(regex)).map(([key, value]) => [
+      key.replace(regex, ""),
+      value,
+    ])
+  )
+}


### PR DESCRIPTION
### Updates `currentUser.authenticate()` to use execService

- Update all calls to `execService` with parameter destructuring.
- Move `authn` config to iframe/pop body
- Add new `discovery.wallet.method` config